### PR TITLE
move md3 to initial position when hardware trigger=False when running…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mx3-beamline-library"
-version = "0.2.11"
+version = "0.2.12"
 description = "Ophyd devices and bluesky plans."
 authors = ["Stephen Mudie <stephenm@ansto.gov.au>"]
 


### PR DESCRIPTION
When running a grid scan with `harware_trigger=False`, we now drive the md3 back to its centered position