### PR TITLE
Update mount/unmount plans

### DIFF
--- a/mx3_beamline_library/config.py
+++ b/mx3_beamline_library/config.py
@@ -1,3 +1,4 @@
+import ast
 from os import environ, path
 
 import yaml
@@ -18,6 +19,18 @@ REDIS_PORT = int(environ.get("REDIS_PORT", "6379"))
 REDIS_USERNAME = environ.get("REDIS_USERNAME", None)
 REDIS_PASSWORD = environ.get("REDIS_PASSWORD", None)
 REDIS_DB = int(environ.get("REDIS_DB", "0"))
+
+# Beam center
+BEAM_CENTER_16M = ast.literal_eval(environ.get("BEAM_CENTER_16M", "(2000, 2144)"))
+
+# Detector
+SIMPLON_API = environ.get("SIMPLON_API", "http://0.0.0.0:8000")
+
+# MD3
+MD3_HOST = environ.get("MD3_REDIS_HOST", "localhost")
+MD3_PORT = environ.get("MD3_REDIS_PORT", "8379")
+MD3_DB = environ.get("MD3_REDIS_DB", "0")
+
 
 try:
     redis_connection = StrictRedis(

--- a/mx3_beamline_library/config.py
+++ b/mx3_beamline_library/config.py
@@ -21,7 +21,7 @@ REDIS_PASSWORD = environ.get("REDIS_PASSWORD", None)
 REDIS_DB = int(environ.get("REDIS_DB", "0"))
 
 # Beam center
-BEAM_CENTER_16M = ast.literal_eval(environ.get("BEAM_CENTER_16M", "(2000, 2144)"))
+BEAM_CENTER_16M = ast.literal_eval(environ.get("BEAM_CENTER_16M", "(2030, 2145)"))
 
 # Detector
 SIMPLON_API = environ.get("SIMPLON_API", "http://0.0.0.0:8000")

--- a/mx3_beamline_library/devices/detectors.py
+++ b/mx3_beamline_library/devices/detectors.py
@@ -1,17 +1,10 @@
 """ Beamline detectors """
 
-from os import environ
-
+from ..config import MD3_DB, MD3_HOST, MD3_PORT, SIMPLON_API
 from .classes.detectors import BlackFlyCam, DectrisDetector, MDRedisCam
-
-SIMPLON_API = environ.get("SIMPLON_API", "http://0.0.0.0:8000")
 
 dectris_detector = DectrisDetector(REST=SIMPLON_API, name="dectris_detector")
 
 blackfly_camera = BlackFlyCam("MX3MD3ZOOM0", name="blackfly_camera")
 
-_md3_host = environ.get("MD3_REDIS_HOST", "localhost")
-_md3_port = environ.get("MD3_REDIS_PORT", "8379")
-_md3_db = environ.get("MD3_REDIS_DB", "0")
-
-md3_camera = MDRedisCam(r={"host": _md3_host, "port": _md3_port, "db": _md3_db})
+md3_camera = MDRedisCam(r={"host": MD3_HOST, "port": MD3_PORT, "db": MD3_DB})

--- a/mx3_beamline_library/devices/motors.py
+++ b/mx3_beamline_library/devices/motors.py
@@ -1,10 +1,18 @@
 """ Motor configuration and instantiation. """
 
-from .classes.motors import MicroDiffractometer, MxcubeSimulatedPVs
+from ophyd import EpicsSignalRO
+
+from .classes.motors import ASBrickMotor, MicroDiffractometer
 from .classes.robot import IsaraRobot
 
 md3 = MicroDiffractometer()
 
 isara_robot = IsaraRobot(name="robot")
 
-mxcube_sim_PVs = MxcubeSimulatedPVs("MXCUBE", name="mxcube_sim_PVs")
+detector_fast_stage = ASBrickMotor("MX3STG03MOT04", name="detector_fast_stage")
+
+detector_slow_stage = ASBrickMotor("MX3STG03MOT01", name="detector_slow_stage")
+
+actual_sample_detector_distance = EpicsSignalRO(
+    "MX3ES01:SAMPLE_DETECTOR_DISTANCE", name="actual_sample_detector_distance"
+)

--- a/mx3_beamline_library/devices/sim/classes/motors.py
+++ b/mx3_beamline_library/devices/sim/classes/motors.py
@@ -90,6 +90,7 @@ class MX3SimMotor(SynAxis):
         DeviceStatus
             The status of the device
         """
+        self._time = time.time()
 
         old_setpoint = self.sim_state["setpoint"]
         self.sim_state["setpoint"] = value
@@ -221,15 +222,6 @@ class MX3SimMotor(SynAxis):
     @property
     def state(self):
         return "Ready"
-
-
-class MySimTable(MotorBundle):
-    """A Simulated Generic Table."""
-
-    x = Cpt(MX3SimMotor, name="TEST:X")
-    y = Cpt(MX3SimMotor, name="TEST:Y")
-    z = Cpt(MX3SimMotor, name="TEST:Z")
-    phi = Cpt(MX3SimMotor, name="TEST:PHI")
 
 
 class SimulatedPVs(MotorBundle):

--- a/mx3_beamline_library/devices/sim/detectors.py
+++ b/mx3_beamline_library/devices/sim/detectors.py
@@ -1,9 +1,6 @@
-from os import environ
-
+from ...config import SIMPLON_API
 from ..classes.detectors import DectrisDetector
 from .classes.detectors import SimBlackFlyCam
-
-SIMPLON_API = environ.get("SIMPLON_API", "http://0.0.0.0:8000")
 
 dectris_detector = DectrisDetector(REST=SIMPLON_API, name="dectris_detector")
 

--- a/mx3_beamline_library/devices/sim/motors.py
+++ b/mx3_beamline_library/devices/sim/motors.py
@@ -1,12 +1,26 @@
 """ Simulated motor configuration and instantiation. """
 
-from .classes.motors import IsaraRobot, MySimTable, SimMicroDiffractometer, SimulatedPVs
+from ophyd import Signal
+
+from .classes.motors import (
+    IsaraRobot,
+    MX3SimMotor,
+    SimMicroDiffractometer,
+    SimulatedPVs,
+)
 
 # Simulated testrig motors
-testrig = MySimTable(name="testrig")
 
 md3 = SimMicroDiffractometer(name="md3")
 
 mxcube_sim_PVs = SimulatedPVs(name="mxcube_sim_PVs")
 
 isara_robot = IsaraRobot(name="robot")
+
+detector_fast_stage = MX3SimMotor(name="detector_fast_stage")
+
+detector_slow_stage = MX3SimMotor(name="detector_slow_stage")
+
+actual_sample_detector_distance = Signal(
+    name="actual_sample_detector_distance", value=100
+)

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -94,8 +94,10 @@ def _md3_scan(
     Generator[Msg, None, None]
         A bluesky stub plan
     """
-    # The fast stage detector measures distance in mm
+    # Make sure we set the beam center while in 16M mode
     set_beam_center_16M()
+
+    # The fast stage detector measures distance in mm
     yield from set_actual_sample_detector_distance(detector_distance * 1000)
     motor_positions_model = None
     if motor_positions is not None:
@@ -451,8 +453,10 @@ def md3_grid_scan(
     Generator
         A bluesky stub plan
     """
-    # The fast stage detector measures distance in mm
+    # Make sure we set the beam center while in 16M mode
     set_beam_center_16M()
+
+    # The fast stage detector measures distance in mm
     yield from set_actual_sample_detector_distance(detector_distance * 1000)
 
     assert number_of_columns > 1, "Number of columns must be > 1"

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -18,7 +18,7 @@ from ..devices.motors import md3
 from ..schemas.crystal_finder import MotorCoordinates
 from ..schemas.detector import DetectorConfiguration, UserData
 from ..schemas.xray_centering import MD3ScanResponse, RasterGridCoordinates
-from .beam_utils import beam_center_16M_to_4M, set_beam_center_16M
+from .beam_utils import set_beam_center_16M
 from .plan_stubs import md3_move, set_actual_sample_detector_distance
 
 logger = logging.getLogger(__name__)
@@ -452,7 +452,7 @@ def md3_grid_scan(
         A bluesky stub plan
     """
     # The fast stage detector measures distance in mm
-    beam_center_16M_to_4M()
+    set_beam_center_16M()
     yield from set_actual_sample_detector_distance(detector_distance * 1000)
 
     assert number_of_columns > 1, "Number of columns must be > 1"

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -18,7 +18,8 @@ from ..devices.motors import md3
 from ..schemas.crystal_finder import MotorCoordinates
 from ..schemas.detector import DetectorConfiguration, UserData
 from ..schemas.xray_centering import MD3ScanResponse, RasterGridCoordinates
-from .plan_stubs import md3_move
+from .beam_utils import beam_center_16M_to_4M, set_beam_center_16M
+from .plan_stubs import md3_move, set_actual_sample_detector_distance
 
 logger = logging.getLogger(__name__)
 _stream_handler = logging.StreamHandler()
@@ -93,7 +94,9 @@ def _md3_scan(
     Generator[Msg, None, None]
         A bluesky stub plan
     """
-    # TODO: Drive PVs when the user sets the detector distance and photon energy!
+    # The fast stage detector measures distance in mm
+    set_beam_center_16M()
+    yield from set_actual_sample_detector_distance(detector_distance * 1000)
     motor_positions_model = None
     if motor_positions is not None:
         if type(motor_positions) is dict:
@@ -379,14 +382,14 @@ def md3_grid_scan(
     start_sample_y: float,
     number_of_columns: int,
     md3_exposure_time: float,
+    detector_distance: float,
+    photon_energy: float,
     omega_range: float = 0,
     invert_direction: bool = True,
     use_centring_table: bool = True,
     use_fast_mesh_scans: bool = True,
     user_data: Optional[UserData] = None,
     count_time: Optional[float] = None,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
 ) -> Generator[Msg, None, None]:
     """
     Bluesky plan that configures and arms the detector, the runs an md3 grid scan plan,
@@ -439,15 +442,19 @@ def md3_grid_scan(
         frame_time - 0.0000001 by default. This calculation is done via
         the DetectorConfiguration pydantic model.
     detector_distance : float, optional
-        Detector distance in meters, by default 0.298
+        Detector distance in meters
     photon_energy : float, optional
-        Photon energy in keV, by default 12.7
+        Photon energy in keV
 
     Yields
     ------
     Generator
         A bluesky stub plan
     """
+    # The fast stage detector measures distance in mm
+    beam_center_16M_to_4M()
+    yield from set_actual_sample_detector_distance(detector_distance * 1000)
+
     assert number_of_columns > 1, "Number of columns must be > 1"
 
     frame_rate = number_of_rows / md3_exposure_time

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -11,6 +11,26 @@ logger = setup_logger()
 def set_beam_center_16M(
     simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
 ) -> tuple[float, float]:
+    """
+    Sets the beam center in 16M mode. Note that the simplon api
+    rescales the beam center when switching between 16M and 4M modes
+    automatically, so we ensure that we alwas set the beam center
+    while in 16M mode.
+
+    Parameters
+    ----------
+    simplon_api : str | None, optional
+        The simplon api url, by default None. If None, the environment variable
+        is used.
+    beam_center_16M : tuple[float, float] | None, optional
+        The beam center in 16M mode, by default None. If None,
+        the environment variable is used.
+
+    Returns
+    -------
+    tuple[float, float]
+        The beam center in 16M mode
+    """
     if simplon_api is None:
         simplon_api = SIMPLON_API
 

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -97,7 +97,7 @@ def beam_center_16M_to_4M(
             urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
             json={"value": beam_Y},
         )
-    response.raise_for_status()
+        response.raise_for_status()
     logger.info(f"Beam center set to {(beam_X, beam_Y)}")
     return (beam_X, beam_Y)
 

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -1,0 +1,127 @@
+from urllib.parse import urljoin
+
+from httpx import Client
+
+from ..config import BEAM_CENTER_16M, SIMPLON_API
+from ..logger import setup_logger
+
+logger = setup_logger()
+
+
+def beam_center_16M_to_4M(
+    simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
+) -> tuple[float, float]:
+    """
+    Convert beam center coordinates from 16M to 4M mode, and sets the new
+    beam center values to the simplon API. The final detector
+    roi_mode is set to 4M.
+
+    Parameters
+    ----------
+    simplon_api : str | None
+        Simplon API URL. If None, the default simplon API URL from the
+        environment variable is used.
+    beam_center_16M : tuple[float,float] | None
+        Beam center coordinates in 16M mode. If None, the default beam center
+        is set to BEAM_CENTER_16M (set via the environment variable).
+
+    Returns
+    -------
+    tuple[float,float]
+        Beam center coordinates in 4M mode.
+    """
+    if simplon_api is None:
+        simplon_api = SIMPLON_API
+
+    if beam_center_16M is None:
+        beam_center_16M = BEAM_CENTER_16M
+
+    with Client() as client:
+        response = client.get(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode")
+        )
+        response.raise_for_status()
+        initial_roi_mode = response.json()["value"]
+        if initial_roi_mode == "4M":
+            response = client.put(
+                urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode"),
+                json={"value": "disabled"},
+            )
+            response.raise_for_status()
+
+        # Get 16M detector dimensions
+        response = client.get(
+            urljoin(simplon_api, "detector/api/1.8.0/config/x_pixels_in_detector")
+        )
+        response.raise_for_status()
+        x_pixels_in_detector_16M = response.json()["value"]
+
+        response = client.get(
+            urljoin(simplon_api, "detector/api/1.8.0/config/y_pixels_in_detector")
+        )
+        response.raise_for_status()
+        y_pixels_in_detector_16M = response.json()["value"]
+
+        # Get 4M detector dimensions
+        response = client.put(
+            urljoin(simplon_api, "detector/api/1.8.0/config/roi_mode"),
+            json={"value": "4M"},
+        )
+        response.raise_for_status()
+
+        response = client.get(
+            urljoin(simplon_api, "detector/api/1.8.0/config/x_pixels_in_detector")
+        )
+        response.raise_for_status()
+        x_pixels_in_detector_4M = response.json()["value"]
+
+        response = client.get(
+            urljoin(simplon_api, "detector/api/1.8.0/config/y_pixels_in_detector")
+        )
+        response.raise_for_status()
+        y_pixels_in_detector_4M = response.json()["value"]
+
+    beam_X_offset = (x_pixels_in_detector_16M - x_pixels_in_detector_4M) / 2
+    beam_X = beam_center_16M[0] - beam_X_offset
+
+    beam_Y_offset = (y_pixels_in_detector_16M - y_pixels_in_detector_4M) / 2
+    beam_Y = beam_center_16M[1] - beam_Y_offset
+
+    response = client.put(
+        urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
+        json={"value": beam_X},
+    )
+    response.raise_for_status()
+
+    response = client.put(
+        urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
+        json={"value": beam_Y},
+    )
+    response.raise_for_status()
+    logger.info(f"Beam center set to {(beam_X, beam_Y)}")
+    return (beam_X, beam_Y)
+
+
+def set_beam_center_16M(
+    simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
+) -> tuple[float, float]:
+    if simplon_api is None:
+        simplon_api = SIMPLON_API
+
+    if beam_center_16M is None:
+        beam_center_16M = BEAM_CENTER_16M
+
+    with Client() as client:
+        response = client.put(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
+            json={"value": beam_center_16M[0]},
+        )
+        response.raise_for_status()
+
+        response = client.put(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
+            json={"value": beam_center_16M[1]},
+        )
+        response.raise_for_status()
+    logger.info(f"Beam center set to {beam_center_16M}")
+    return beam_center_16M

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -8,100 +8,6 @@ from ..logger import setup_logger
 logger = setup_logger()
 
 
-def beam_center_16M_to_4M(
-    simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
-) -> tuple[float, float]:
-    """
-    Convert beam center coordinates from 16M to 4M mode, and sets the new
-    beam center values to the simplon API. The final detector
-    roi_mode is set to 4M.
-
-    Parameters
-    ----------
-    simplon_api : str | None
-        Simplon API URL. If None, the default simplon API URL from the
-        environment variable is used.
-    beam_center_16M : tuple[float,float] | None
-        Beam center coordinates in 16M mode. If None, the default beam center
-        is set to BEAM_CENTER_16M (set via the environment variable).
-
-    Returns
-    -------
-    tuple[float,float]
-        Beam center coordinates in 4M mode.
-    """
-    if simplon_api is None:
-        simplon_api = SIMPLON_API
-
-    if beam_center_16M is None:
-        beam_center_16M = BEAM_CENTER_16M
-
-    with Client() as client:
-        response = client.get(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode")
-        )
-        response.raise_for_status()
-        initial_roi_mode = response.json()["value"]
-        if initial_roi_mode == "4M":
-            response = client.put(
-                urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode"),
-                json={"value": "disabled"},
-            )
-            response.raise_for_status()
-
-        # Get 16M detector dimensions
-        response = client.get(
-            urljoin(simplon_api, "detector/api/1.8.0/config/x_pixels_in_detector")
-        )
-        response.raise_for_status()
-        x_pixels_in_detector_16M = response.json()["value"]
-
-        response = client.get(
-            urljoin(simplon_api, "detector/api/1.8.0/config/y_pixels_in_detector")
-        )
-        response.raise_for_status()
-        y_pixels_in_detector_16M = response.json()["value"]
-
-        # Get 4M detector dimensions
-        response = client.put(
-            urljoin(simplon_api, "detector/api/1.8.0/config/roi_mode"),
-            json={"value": "4M"},
-        )
-        response.raise_for_status()
-
-        response = client.get(
-            urljoin(simplon_api, "detector/api/1.8.0/config/x_pixels_in_detector")
-        )
-        response.raise_for_status()
-        x_pixels_in_detector_4M = response.json()["value"]
-
-        response = client.get(
-            urljoin(simplon_api, "detector/api/1.8.0/config/y_pixels_in_detector")
-        )
-        response.raise_for_status()
-        y_pixels_in_detector_4M = response.json()["value"]
-
-        beam_X_offset = (x_pixels_in_detector_16M - x_pixels_in_detector_4M) / 2
-        beam_X = beam_center_16M[0] - beam_X_offset
-
-        beam_Y_offset = (y_pixels_in_detector_16M - y_pixels_in_detector_4M) / 2
-        beam_Y = beam_center_16M[1] - beam_Y_offset
-
-        response = client.put(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
-            json={"value": beam_X},
-        )
-        response.raise_for_status()
-
-        response = client.put(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
-            json={"value": beam_Y},
-        )
-        response.raise_for_status()
-    logger.info(f"Beam center set to {(beam_X, beam_Y)}")
-    return (beam_X, beam_Y)
-
-
 def set_beam_center_16M(
     simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
 ) -> tuple[float, float]:
@@ -112,6 +18,12 @@ def set_beam_center_16M(
         beam_center_16M = BEAM_CENTER_16M
 
     with Client() as client:
+        # Set beam center in 16M mode
+        response = client.put(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode"),
+            json={"value": "disabled"},
+        )
+        response.raise_for_status()
         response = client.put(
             urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
             json={"value": beam_center_16M[0]},

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -81,22 +81,22 @@ def beam_center_16M_to_4M(
         response.raise_for_status()
         y_pixels_in_detector_4M = response.json()["value"]
 
-    beam_X_offset = (x_pixels_in_detector_16M - x_pixels_in_detector_4M) / 2
-    beam_X = beam_center_16M[0] - beam_X_offset
+        beam_X_offset = (x_pixels_in_detector_16M - x_pixels_in_detector_4M) / 2
+        beam_X = beam_center_16M[0] - beam_X_offset
 
-    beam_Y_offset = (y_pixels_in_detector_16M - y_pixels_in_detector_4M) / 2
-    beam_Y = beam_center_16M[1] - beam_Y_offset
+        beam_Y_offset = (y_pixels_in_detector_16M - y_pixels_in_detector_4M) / 2
+        beam_Y = beam_center_16M[1] - beam_Y_offset
 
-    response = client.put(
-        urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
-        json={"value": beam_X},
-    )
-    response.raise_for_status()
+        response = client.put(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
+            json={"value": beam_X},
+        )
+        response.raise_for_status()
 
-    response = client.put(
-        urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
-        json={"value": beam_Y},
-    )
+        response = client.put(
+            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
+            json={"value": beam_Y},
+        )
     response.raise_for_status()
     logger.info(f"Beam center set to {(beam_X, beam_Y)}")
     return (beam_X, beam_Y)

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -35,5 +35,5 @@ def set_beam_center_16M(
             json={"value": beam_center_16M[1]},
         )
         response.raise_for_status()
-    logger.info(f"Beam center set to {beam_center_16M}")
+    logger.info(f"16M beam center set to {beam_center_16M}")
     return beam_center_16M

--- a/mx3_beamline_library/plans/plan_stubs.py
+++ b/mx3_beamline_library/plans/plan_stubs.py
@@ -110,7 +110,8 @@ def set_actual_sample_detector_distance(
 
     fast_stage_setpoint = current_fast_stage_val + diff
     # Current fast_stage motor does not have limits
-    if fast_stage_setpoint <= 82 or fast_stage_setpoint >= 650:
+    limits = detector_fast_stage.limits
+    if fast_stage_setpoint <= limits[0] or fast_stage_setpoint >= limits[1]:
         raise ValueError(f"Setpoint {fast_stage_setpoint} out of limits")
 
     yield from mv(detector_fast_stage, fast_stage_setpoint)

--- a/mx3_beamline_library/plans/plan_stubs.py
+++ b/mx3_beamline_library/plans/plan_stubs.py
@@ -112,6 +112,8 @@ def set_actual_sample_detector_distance(
     # Current fast_stage motor does not have limits
     limits = detector_fast_stage.limits
     if fast_stage_setpoint <= limits[0] or fast_stage_setpoint >= limits[1]:
-        raise ValueError(f"Setpoint {fast_stage_setpoint} out of limits")
+        raise ValueError(
+            f"Detector fast stage setpoint {fast_stage_setpoint} is out of limits: {limits}"
+        )
 
     yield from mv(detector_fast_stage, fast_stage_setpoint)

--- a/mx3_beamline_library/plans/plan_stubs.py
+++ b/mx3_beamline_library/plans/plan_stubs.py
@@ -3,13 +3,14 @@ import uuid
 from functools import reduce
 from typing import Generator, Union
 
-from bluesky.plan_stubs import create, mv, read, save
+from bluesky.plan_stubs import create, mv, rd, read, save
 from bluesky.utils import Msg, merge_cycler
 from cycler import cycler
 from ophyd import Device, Signal
 
 from ..config import BL_ACTIVE
 from ..devices.classes.motors import SERVER
+from ..devices.motors import actual_sample_detector_distance, detector_fast_stage
 
 try:
     # cytools is a drop-in replacement for toolz, implemented in Cython
@@ -78,3 +79,38 @@ def move_and_emit_document(
     yield from mv(signal, value)
     yield from read(signal)
     yield from save()
+
+
+def set_actual_sample_detector_distance(
+    actual_detector_distance_setpoint: float,
+) -> Generator[Msg, None, None]:
+    """
+    Sets the actual detector distance from the sample to the detector
+    by moving the detector fast stage
+
+    Parameters
+    ----------
+    actual_detector_distance_setpoint : float
+        The actual_detector_distance_setpoint in mm
+
+    Yields
+    ------
+    Generator[Msg, None, None]
+        A bluesky message
+
+    Raises
+    ------
+    ValueError
+        Raises an error if the setpoint is out of the limits
+        of the fast stage
+    """
+    actual_distance = actual_sample_detector_distance.get()
+    diff = actual_detector_distance_setpoint - actual_distance
+    current_fast_stage_val = yield from rd(detector_fast_stage)
+
+    fast_stage_setpoint = current_fast_stage_val + diff
+    # Current fast_stage motor does not have limits
+    if fast_stage_setpoint <= 82 or fast_stage_setpoint >= 650:
+        raise ValueError("Setpoint out of limits")
+
+    yield from mv(detector_fast_stage, fast_stage_setpoint)

--- a/mx3_beamline_library/plans/plan_stubs.py
+++ b/mx3_beamline_library/plans/plan_stubs.py
@@ -111,6 +111,6 @@ def set_actual_sample_detector_distance(
     fast_stage_setpoint = current_fast_stage_val + diff
     # Current fast_stage motor does not have limits
     if fast_stage_setpoint <= 82 or fast_stage_setpoint >= 650:
-        raise ValueError("Setpoint out of limits")
+        raise ValueError(f"Setpoint {fast_stage_setpoint} out of limits")
 
     yield from mv(detector_fast_stage, fast_stage_setpoint)

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -31,6 +31,7 @@ def mount_pin(
     yield from open_run()
     if md3.phase.get() != "Transfer":
         yield from mv(md3.phase, "Transfer")
+    yield from set_actual_sample_detector_distance(500)
     yield from mv(isara_robot.mount, {"pin": pin, "prepick_pin": prepick_pin})
     yield from mv(md3.phase, "Centring")
     yield from close_run()

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -31,6 +31,8 @@ def mount_pin(
     yield from open_run()
     if md3.phase.get() != "Transfer":
         yield from mv(md3.phase, "Transfer")
+    # TODO: The "500" number can be pulled from somewhere else
+    # e.g. bitbucket config
     yield from set_actual_sample_detector_distance(500)
     yield from mv(isara_robot.mount, {"pin": pin, "prepick_pin": prepick_pin})
     yield from mv(md3.phase, "Centring")

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -31,9 +31,7 @@ def mount_pin(
     yield from open_run()
     if md3.phase.get() != "Transfer":
         yield from mv(md3.phase, "Transfer")
-    # TODO: The "500" number can be pulled from somewhere else
-    # e.g. bitbucket config
-    yield from set_actual_sample_detector_distance(500)
+    yield from set_actual_sample_detector_distance(380)
     yield from mv(isara_robot.mount, {"pin": pin, "prepick_pin": prepick_pin})
     yield from mv(md3.phase, "Centring")
     yield from close_run()
@@ -50,7 +48,7 @@ def unmount_pin() -> Generator[Msg, None, None]:
     """
     yield from open_run()
     yield from mv(md3.phase, "Transfer")
-    yield from set_actual_sample_detector_distance(500)
+    yield from set_actual_sample_detector_distance(380)
     yield from mv(isara_robot.unmount, None)
     yield from close_run()
 

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -6,6 +6,7 @@ from bluesky.utils import Msg
 from mx_robot_library.schemas.common.sample import Pin
 
 from ..devices.motors import isara_robot, md3
+from .plan_stubs import set_actual_sample_detector_distance
 
 
 def mount_pin(
@@ -46,6 +47,7 @@ def unmount_pin() -> Generator[Msg, None, None]:
     """
     yield from open_run()
     yield from mv(md3.phase, "Transfer")
+    yield from set_actual_sample_detector_distance(500)
     yield from mv(isara_robot.unmount, None)
     yield from close_run()
 

--- a/mx3_beamline_library/plans/xray_centering.py
+++ b/mx3_beamline_library/plans/xray_centering.py
@@ -46,8 +46,8 @@ class XRayCentering:
         grid_scan_id: str
             Grid scan type, could be either `flat`, or `edge`.
         detector_distance: float
-            The detector distance
-        photon_energy: float, optional
+            The detector distance in meters
+        photon_energy: float
             The photon energy in keV
         omega_range : float, optional
             Omega range (degrees) for the scan, by default 0
@@ -215,6 +215,7 @@ class XRayCentering:
         None
 
         """
+
         logger.info("Starting raster scan...")
         logger.info(f"Number of columns: {grid.number_of_columns}")
         logger.info(f"Number of rows: {grid.number_of_rows}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mx3-beamline-library"
-version = "1.2.0"
+version = "1.2.1"
 description = "Ophyd devices and bluesky plans."
 authors = ["Stephen Mudie <stephenm@ansto.gov.au>"]
 


### PR DESCRIPTION
* The detector is now moved to a safe position before mounting and unmounting samples
* Adds ophyd devices to drive the detector fast and slow stage
* Adds simulated ophyd devices drive the detector fast and slow stage
* Sets the beam center in 16M mode when we run md3 scans and grid scans. The beam center is set via the environment variable `BEAM_CENTER_16M`
* Moved some environment varialbes to the configuration file