### PR TITLE
Update tray scans

### DIFF
--- a/examples/tray_grid_scans.py
+++ b/examples/tray_grid_scans.py
@@ -39,11 +39,12 @@ RE.subscribe(bec)
 RE(
     multiple_drop_grid_scan(
         tray_id="my_tray",
-        detector=dectris_detector,
         drop_locations=["A1-1", "A2-1", "B1-1", "B2-1"],
+        detector_distance=0.496,
+        photon_energy=13,
         grid_number_of_columns=5,
         grid_number_of_rows=5,
-        exposure_time=0.6,
+        md3_alignment_y_speed=1,
         omega_range=0,
         alignment_y_offset=0.2,
         alignment_z_offset=-1.0,

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -261,6 +261,19 @@ def _md3_scan(
             f"Scan did not run successfully: {scan_response.model_dump()}"
         )
 
+    if tray_scan:
+        # Move tray back to either 91 or 270 degrees depending on the tray type
+        omega_position = md3.omega.position
+        if 70 <= omega_position <= 110:
+            yield from mv(md3.omega, 91)
+        elif 250 <= omega_position <= 290:
+            yield from mv(md3.omega, 270)
+        else:
+            raise ValueError(
+                "Start omega should either be in the range (70,110) "
+                f"or (250,290). Current value is {omega_position}"
+            )
+
     return scan_response
 
 

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -35,14 +35,14 @@ def _md3_scan(
     number_of_frames: int,
     scan_range: float,
     exposure_time: float,
+    detector_distance: float,
+    photon_energy: float,
     number_of_passes: int = 1,
     motor_positions: MotorCoordinates | None = None,
     tray_scan: bool = False,
     count_time: float | None = None,
     drop_location: str | None = None,
     hardware_trigger: bool = True,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
     crystal_id: int = 0,
     data_collection_id: int = 0,
 ) -> Generator[Msg, None, None]:
@@ -58,10 +58,10 @@ def _md3_scan(
     scan_range : float
         The range of the scan in degrees.
     exposure_time : float
-        The exposure time in seconds. NOTE: This is NOT the MD3 definition of exposure time
+        The total exposure time in seconds.
     number_of_passes : int, optional
         The number of passes, by default 1
-    motor_positions : Union[MotorCoordinates, None], optional
+    motor_positions : MotorCoordinates | None, optional
         The motor positions at which the scan is done. The motor positions
         usually are inferred by the crystal finder.
     tray_scan : bool, optional
@@ -282,19 +282,20 @@ def md3_scan(
     number_of_frames: int,
     scan_range: float,
     exposure_time: float,
+    detector_distance: float,
+    photon_energy: float,
     number_of_passes: int = 1,
     tray_scan: bool = False,
     motor_positions: MotorCoordinates | None = None,
     count_time: float | None = None,
     drop_location: str | None = None,
     hardware_trigger: bool = True,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
     crystal_id: int = 0,
     data_collection_id: int = 0,
 ) -> Generator[Msg, None, None]:
     """
-    Runs an MD3 scan on a crystal.
+    Runs an MD3 scan on a crystal. If tray_scan=True, the start angle of the scan is either
+    a) 91 - scan_range/2 or b) 270 - scan_range/2 (depending on the tray type)
 
     Parameters
     ----------
@@ -305,7 +306,11 @@ def md3_scan(
     scan_range : float
         The range of the scan in degrees
     exposure_time : float
-        The exposure time in seconds
+        The total exposure time in seconds
+    detector_distance: float
+        The detector distance in meters
+    photon_energy: float,
+        The photon energy in keV
     number_of_passes : int, optional
         The number of passes, by default 1
     motor_positions : Union[MotorCoordinates, dict], optional
@@ -327,10 +332,6 @@ def md3_scan(
         If set to true, we trigger the detector via hardware trigger, by default True.
         Warning! hardware_trigger=False is used mainly for development purposes,
         as it results in a very slow scan
-    detector_distance: float
-        The detector distance, by default 0.298
-    photon_energy: float,
-        The photon energy in keV, by default 12.7
     crystal_id : int, optional
         The id of the crystal in the tray or pin, by default 0
     data_collection_id : int, optional

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from time import perf_counter
-from typing import Generator, Optional, Union
+from typing import Generator, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -36,15 +36,15 @@ def _md3_scan(
     scan_range: float,
     exposure_time: float,
     number_of_passes: int = 1,
-    motor_positions: Union[MotorCoordinates, dict, None] = None,
+    motor_positions: MotorCoordinates | None = None,
     tray_scan: bool = False,
-    count_time: Optional[float] = None,
-    drop_location: Optional[str] = None,
+    count_time: float | None = None,
+    drop_location: str | None = None,
     hardware_trigger: bool = True,
     detector_distance: float = 0.298,
     photon_energy: float = 12.7,
-    crystal_id: Optional[int] = 0,
-    data_collection_id: Optional[int] = 0,
+    crystal_id: int = 0,
+    data_collection_id: int = 0,
 ) -> Generator[Msg, None, None]:
     """
     Runs an MD3 scan on a crystal.
@@ -56,20 +56,18 @@ def _md3_scan(
     number_of_frames : int
         The number of detector frames
     scan_range : float
-        The range of the scan in degrees
+        The range of the scan in degrees.
     exposure_time : float
         The exposure time in seconds. NOTE: This is NOT the MD3 definition of exposure time
     number_of_passes : int, optional
         The number of passes, by default 1
-    motor_positions : Union[MotorCoordinates, dict], optional
+    motor_positions : Union[MotorCoordinates, None], optional
         The motor positions at which the scan is done. The motor positions
-        usually are inferred by the crystal finder. NOTE: We allow
-        for dictionary types because the values sent via the
-        bluesky queueserver do not support pydantic models.
-        If motor_positions is None. We run a scan at the current position
-        of the MD3
+        usually are inferred by the crystal finder.
     tray_scan : bool, optional
-        Determines if the scan is done on a tray, by default False
+        Determines if the scan is done on a tray, by default False. If tray_scan=True,
+        the start angle of the scan is either a) 91 - scan_range/2 or
+        b) 270 - scan_range/2 (depending on the tray type)
     count_time : float, optional
         Detector count time. If this parameter is not set, it is set to
         frame_time - 0.0000001 by default. This calculation is done via
@@ -101,19 +99,7 @@ def _md3_scan(
     yield from set_actual_sample_detector_distance(detector_distance * 1000)
     motor_positions_model = None
     if motor_positions is not None:
-        if type(motor_positions) is dict:
-            motor_positions_model = MotorCoordinates(
-                sample_x=motor_positions["sample_x"],
-                sample_y=motor_positions["sample_y"],
-                alignment_x=motor_positions["alignment_x"],
-                alignment_y=motor_positions["alignment_y"],
-                alignment_z=motor_positions["alignment_z"],
-                omega=motor_positions["omega"],
-                plate_translation=motor_positions.get("plate_translation"),
-            )
-        else:
-            motor_positions_model = motor_positions
-
+        motor_positions_model = motor_positions
         if not tray_scan:
             yield from md3_move(
                 md3.sample_x,
@@ -130,6 +116,11 @@ def _md3_scan(
                 motor_positions_model.omega,
             )
         else:
+            if scan_range > 30:
+                raise ValueError(
+                    "Scan range for trays cannot exceed 30 degrees. "
+                    "Decrease the scan range"
+                )
             yield from md3_move(
                 md3.sample_x,
                 motor_positions_model.sample_x,
@@ -182,10 +173,29 @@ def _md3_scan(
     if BL_ACTIVE == "true":
         if hardware_trigger:
             scan_idx = 1  # NOTE: This does not seem to serve any useful purpose
-            if motor_positions_model is None:
-                initial_omega = md3.omega.position
+            if tray_scan:
+                omega_position = md3.omega.position
+                # There's only two start omega positions depending on the tray type:
+                # 91 or 270 degrees. Here, we infer start omega based
+                # on the current omega position
+                if 70 <= omega_position <= 110:
+                    yield from mv(md3.omega, 91)
+                    initial_omega = 91 - scan_range / 2
+                elif 250 <= omega_position <= 290:
+                    yield from mv(md3.omega, 270)
+                    initial_omega = 270 - scan_range / 2
+                else:
+                    raise ValueError(
+                        "Start omega should either be in the range (70,110) "
+                        f"or (250,290). Current value is {omega_position}"
+                    )
             else:
-                initial_omega = motor_positions_model.omega
+                # Loop screening or data collection
+                if motor_positions_model is None:
+                    initial_omega = md3.omega.position
+                else:
+                    initial_omega = motor_positions_model.omega
+
             scan_id: int = SERVER.startScanEx2(
                 scan_idx,
                 number_of_frames,
@@ -228,7 +238,6 @@ def _md3_scan(
 
     MD3_SCAN_RESPONSE.put(str(scan_response.model_dump()))
     yield from unstage(dectris_detector)
-    yield from mv(md3.omega, 91.0)
 
     if scan_response.task_exception.lower() != "null":
         raise RuntimeError(
@@ -245,14 +254,14 @@ def md3_scan(
     exposure_time: float,
     number_of_passes: int = 1,
     tray_scan: bool = False,
-    motor_positions: Union[MotorCoordinates, dict, None] = None,
-    count_time: Optional[float] = None,
-    drop_location: Optional[str] = None,
+    motor_positions: MotorCoordinates | None = None,
+    count_time: float | None = None,
+    drop_location: str | None = None,
     hardware_trigger: bool = True,
     detector_distance: float = 0.298,
     photon_energy: float = 12.7,
-    crystal_id: Optional[int] = 0,
-    data_collection_id: Optional[int] = 0,
+    crystal_id: int = 0,
+    data_collection_id: int = 0,
 ) -> Generator[Msg, None, None]:
     """
     Runs an MD3 scan on a crystal.

--- a/mx3_beamline_library/plans/commissioning/stats.py
+++ b/mx3_beamline_library/plans/commissioning/stats.py
@@ -150,8 +150,7 @@ class Scan1DStats:
 
     def _find_peak(self, x_tmp: npt.NDArray, y_tmp: npt.NDArray) -> tuple[float, float]:
         """Finds the peak of a a curve. The peak returned is the maximum (or minimum
-        if the Gaussian is inverted) peak when comparing the peak height between the
-        fitted Gaussian and the raw data.
+        if the Gaussian is inverted) of the fitted curve, NOT the raw data.
 
         Parameters
         ----------
@@ -170,29 +169,26 @@ class Scan1DStats:
                 x_tmp[np.argmax(y_tmp)],
                 -1 * y_tmp[np.argmax(y_tmp)] * self.normalisation_constant,
             )
-            peak_raw_data = (
-                self.x_array[np.argmax(self.y_array)],
-                -1 * self.y_array[np.argmax(self.y_array)],
-            )
-            if peak_raw_data[1] < peak_fitted_curve[1]:
-                return peak_raw_data
-            else:
-                return peak_fitted_curve
+
+            # This is the peak of the raw data if needed
+            # peak_raw_data = (
+            #     self.x_array[np.argmax(self.y_array)],
+            #     -1 * self.y_array[np.argmax(self.y_array)],
+            # )
+            return peak_fitted_curve
 
         else:
             peak_fitted_curve = (
                 x_tmp[np.argmax(y_tmp)],
                 y_tmp[np.argmax(y_tmp)] * self.normalisation_constant,
             )
-            peak_raw_data = (
-                self.x_array[np.argmax(self.y_array)],
-                self.y_array[np.argmax(self.y_array)],
-            )
+            # This is the peak of the raw data if needed
+            # peak_raw_data = (
+            #     self.x_array[np.argmax(self.y_array)],
+            #     self.y_array[np.argmax(self.y_array)],
+            # )
 
-            if peak_raw_data[1] > peak_fitted_curve[1]:
-                return peak_raw_data
-            else:
-                return peak_fitted_curve
+            return peak_fitted_curve
 
     def _full_width_at_half_maximum(
         self, x: npt.NDArray, y: npt.NDArray

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -106,8 +106,8 @@ def _single_drop_grid_scan(
         )
 
     # TODO: support more tray types.
-    grid_height = 2.7  # mm
-    grid_width = 2.7  # mm
+    grid_height = 1.3  # mm
+    grid_width = 1.3 # mm
 
     frame_time = grid_height / (md3_alignment_y_speed * grid_number_of_rows)
     frame_rate = 1 / frame_time

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -137,6 +137,9 @@ def _single_drop_grid_scan(
     if md3.phase.get() != "DataCollection":
         yield from mv(md3.phase, "DataCollection")
 
+    # FIXME, TODO: move_plate_to_shelf is not accurate at the moment
+    # We need to create our own configuration containing
+    # the drop locations and the corresponding motor positions
     # yield from mv(md3.move_plate_to_shelf, drop_location)
 
     logger.info(f"Plate moved to {drop_location}")

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -137,14 +137,14 @@ def _single_drop_grid_scan(
     if md3.phase.get() != "DataCollection":
         yield from mv(md3.phase, "DataCollection")
 
-    yield from mv(md3.move_plate_to_shelf, drop_location)
+    #yield from mv(md3.move_plate_to_shelf, drop_location)
 
     logger.info(f"Plate moved to {drop_location}")
 
     start_alignment_y = md3.alignment_y.position + alignment_y_offset - grid_height / 2
     # NOTE: 0.86 is the alignment_z default value when
     # the md3 is set to data collection mode
-    start_alignment_z = 0.86 + alignment_z_offset - grid_width / 2
+    start_alignment_z = alignment_z_offset - grid_width / 2
     sample_x_position = md3.sample_x.position
     sample_y_position = md3.sample_y.position
 

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -107,7 +107,7 @@ def _single_drop_grid_scan(
 
     # TODO: support more tray types.
     grid_height = 1.3  # mm
-    grid_width = 1.3 # mm
+    grid_width = 1.3  # mm
 
     frame_time = grid_height / (md3_alignment_y_speed * grid_number_of_rows)
     frame_rate = 1 / frame_time
@@ -123,7 +123,7 @@ def _single_drop_grid_scan(
             "Decrease the md3 alignment y speed"
         )
 
-    md3_exposure_time = grid_number_of_rows * frame_time
+    md3_exposure_time = grid_height / md3_alignment_y_speed
 
     delta_x = grid_width / grid_number_of_columns
     # If grid_width / grid_number_of_columns is too big,
@@ -137,14 +137,13 @@ def _single_drop_grid_scan(
     if md3.phase.get() != "DataCollection":
         yield from mv(md3.phase, "DataCollection")
 
-    #yield from mv(md3.move_plate_to_shelf, drop_location)
+    # yield from mv(md3.move_plate_to_shelf, drop_location)
 
     logger.info(f"Plate moved to {drop_location}")
 
     start_alignment_y = md3.alignment_y.position + alignment_y_offset - grid_height / 2
-    # NOTE: 0.86 is the alignment_z default value when
-    # the md3 is set to data collection mode
-    start_alignment_z = alignment_z_offset - grid_width / 2
+
+    start_alignment_z = md3.alignment_z.position + alignment_z_offset - grid_width / 2
     sample_x_position = md3.sample_x.position
     sample_y_position = md3.sample_y.position
 

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -30,16 +30,16 @@ MD3_SCAN_RESPONSE = Signal(name="md3_scan_response", kind="normal")
 def _single_drop_grid_scan(
     tray_id: str,
     drop_location: str,
+    detector_distance: float,
+    photon_energy: float,
     grid_number_of_columns: int = 15,
     grid_number_of_rows: int = 15,
-    exposure_time: float = 1,
+    md3_alignment_y_speed: float = 1.0,
     omega_range: float = 0,
     count_time: Optional[float] = None,
     alignment_y_offset: float = 0.2,
     alignment_z_offset: float = -1.0,
     hardware_trigger: bool = True,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
 ) -> Generator[Msg, None, None]:
     """
     Runs a grid-scan on a single drop. If the beamline library is in
@@ -53,13 +53,16 @@ def _single_drop_grid_scan(
         The id of the tray
     drop_location : str
         The drop location, e.g. "A1-1"
+    detector_distance: float, optional
+        Detector distance in meters
+    photon_energy: float, optional
+        Photon energy in keV
     grid_number_of_columns : int, optional
         Number of columns of the grid scan, by default 15
     grid_number_of_rows : int, optional
         Number of rows of the grid scan, by default 15
-    exposure_time : float, optional
-        Exposure time (also known as frame time). NOTE: This is NOT the
-        exposure time as defined by the MD3.
+    md3_alignment_y_speed : float, optional
+        The md3 alignment y speed, by default 1.0
     omega_range : float, optional
         Omega range of the grid scan, by default 0
     user_data : UserData, optional
@@ -77,10 +80,6 @@ def _single_drop_grid_scan(
         If set to true, we trigger the detector via hardware trigger, by default True.
         Warning! hardware_trigger=False is used mainly for debugging purposes,
         as it results in a very slow scan
-    detector_distance: float, optional
-        Detector distance in meters, by default 0.298
-    photon_energy: float, optional
-        Photon energy in keV, by default 12.7
 
     Yields
     ------
@@ -95,29 +94,45 @@ def _single_drop_grid_scan(
         number_of_rows=grid_number_of_rows,
         grid_scan_id=drop_location,
     )
-    assert omega_range <= 10.3, "omega_range must be less that 10.3 degrees"
-    # The following seems to be a good approximation of the width of a single drop
-    # of the Crystal QuickX2 tray type
+    if md3_alignment_y_speed > 14.8:
+        raise ValueError(
+            "The maximum allowed md3 alignment y speed is 14.8 mm/s, but "
+            f"the requested value is {md3_alignment_y_speed} mm/s. "
+        )
+    if omega_range > 10.3:
+        raise ValueError(
+            "The maximum allowed omega range is 10.3 degrees, but "
+            f"the requested value is {omega_range} degrees. "
+        )
+
     # TODO: support more tray types.
-    grid_height = 2.7
-    grid_width = 2.7
+    grid_height = 2.7  # mm
+    grid_width = 2.7  # mm
 
-    md3_exposure_time = grid_number_of_rows * exposure_time
+    frame_time = grid_height / (md3_alignment_y_speed * grid_number_of_rows)
+    frame_rate = 1 / frame_time
+    number_of_frames = grid_number_of_columns * grid_number_of_rows
+    logger.info(f"Frame time: {frame_time} s")
+    logger.info(f"Frame rate: {frame_rate} Hz")
+    logger.info(f"Number of frames: {number_of_frames}")
 
-    y_axis_speed = grid_height / md3_exposure_time
+    if frame_rate > 1000:
+        raise ValueError(
+            "The maximum allowed frame rate is 1000 Hz, but "
+            f"the requested value is {frame_rate} Hz. "
+            "Decrease the md3 alignment y speed"
+        )
 
-    assert y_axis_speed < 14.8, (
-        "grid_height / md3_exposure_time be less than 15 mm/s. The current value is "
-        f"{y_axis_speed}. Increase the exposure time. "
-    )
+    md3_exposure_time = grid_number_of_rows * frame_time
 
     delta_x = grid_width / grid_number_of_columns
     # If grid_width / grid_number_of_columns is too big,
     # the MD3 grid scan does not run successfully
-    assert delta_x <= 0.85, (
-        "grid_width / grid_number_of_columns must be less than 0.85. "
-        f"The current value is {delta_x}. Increase the number of columns"
-    )
+    if delta_x > 0.85:
+        raise ValueError(
+            "grid_width / grid_number_of_columns must be less than 0.85. "
+            f"The current value is {delta_x}. Increase the number of columns"
+        )
 
     if md3.phase.get() != "DataCollection":
         yield from mv(md3.phase, "DataCollection")
@@ -234,16 +249,16 @@ def _single_drop_grid_scan(
 def single_drop_grid_scan(
     tray_id: str,
     drop_location: str,
+    detector_distance: float,
+    photon_energy: float,
     grid_number_of_columns: int = 15,
     grid_number_of_rows: int = 15,
-    exposure_time: float = 1,
+    md3_alignment_y_speed: float = 1.0,
     omega_range: float = 0,
     count_time: Optional[float] = None,
     alignment_y_offset: float = 0.2,
     alignment_z_offset: float = -1.0,
     hardware_trigger: bool = True,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
 ) -> Generator[Msg, None, None]:
     """
     Wrapper of the _single_drop_grid_scan function. This allows us to
@@ -255,6 +270,10 @@ def single_drop_grid_scan(
         Detector ophyd device
     drop_location : str
         The drop location, e.g. "A1-1"
+    detector_distance: float
+        Detector distance in meters
+    photon_energy: float
+        Photon energy in keV
     grid_number_of_columns : int, optional
         Number of columns of the grid scan, by default 15
     grid_number_of_rows : int, optional
@@ -279,10 +298,6 @@ def single_drop_grid_scan(
         If set to true, we trigger the detector via hardware trigger, by default True.
         Warning! hardware_trigger=False is used mainly for debugging purposes,
         as it results in a very slow scan
-    detector_distance: float, optional
-        Detector distance in meters, by default 0.298
-    photon_energy: float, optional
-        Photon energy in keV, by default 12.7
 
     Yields
     ------
@@ -297,7 +312,7 @@ def single_drop_grid_scan(
                 drop_location=drop_location,
                 grid_number_of_columns=grid_number_of_columns,
                 grid_number_of_rows=grid_number_of_rows,
-                exposure_time=exposure_time,
+                md3_alignment_y_speed=md3_alignment_y_speed,
                 omega_range=omega_range,
                 count_time=count_time,
                 alignment_y_offset=alignment_y_offset,
@@ -315,16 +330,16 @@ def single_drop_grid_scan(
 def multiple_drop_grid_scan(
     tray_id: str,
     drop_locations: list[str],
+    detector_distance: float,
+    photon_energy: float,
     grid_number_of_columns: int = 15,
     grid_number_of_rows: int = 15,
-    exposure_time: float = 1,
+    md3_alignment_y_speed: float = 1,
     omega_range: float = 0,
     count_time: Optional[float] = None,
     alignment_y_offset: float = 0.2,
     alignment_z_offset: float = -1.0,
     hardware_trigger: bool = True,
-    detector_distance: float = 0.298,
-    photon_energy: float = 12.7,
 ) -> Generator[Msg, None, None]:
     """
     Runs one grid scan per drop. The drop locations are specified in the
@@ -336,6 +351,10 @@ def multiple_drop_grid_scan(
         The id of the tray
     drop_locations : list[str]
         A list of drop locations, e.g. ["A1-1", "A1-2"]
+    detector_distance: float
+        Detector distance in meters
+    photon_energy: float
+        Photon energy in keV
     grid_number_of_columns : int, optional
         Number of columns of the grid scan, by default 15
     grid_number_of_rows : int, optional
@@ -363,10 +382,6 @@ def multiple_drop_grid_scan(
         If set to true, we trigger the detector via hardware trigger, by default True.
         Warning! hardware_trigger=False is used mainly for debugging purposes,
         as it results in a very slow scan
-    detector_distance: float, optional
-        Detector distance in meters, by default 0.298
-    photon_energy: float, optional
-        Photon energy in keV, by default 12.7
 
     Yields
     ------
@@ -381,7 +396,7 @@ def multiple_drop_grid_scan(
             drop_location=drop,
             grid_number_of_columns=grid_number_of_columns,
             grid_number_of_rows=grid_number_of_rows,
-            exposure_time=exposure_time,
+            md3_alignment_y_speed=md3_alignment_y_speed,
             omega_range=omega_range,
             count_time=count_time,
             alignment_y_offset=alignment_y_offset,

--- a/mx3_beamline_library/plans/xray_centering.py
+++ b/mx3_beamline_library/plans/xray_centering.py
@@ -188,8 +188,7 @@ class XRayCentering:
                 f"the requested value is {frame_rate} Hz. "
                 "Decrease the md3 alignment y speed"
             )
-
-        md3_exposure_time = grid.number_of_rows * frame_time
+        md3_exposure_time = grid.height_mm / self.md3_alignment_y_speed
         return md3_exposure_time
 
     def _grid_scan(

--- a/mx3_beamline_library/schemas/xray_centering.py
+++ b/mx3_beamline_library/schemas/xray_centering.py
@@ -1,7 +1,6 @@
 from typing import Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-from typing_extensions import Self
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TestrigEventData(BaseModel):

--- a/mx3_beamline_library/schemas/xray_centering.py
+++ b/mx3_beamline_library/schemas/xray_centering.py
@@ -148,8 +148,8 @@ class MD3ScanResponse(BaseModel):
     result_id: int | str = Field(description="Can be null if the scan fails")
     model_config = ConfigDict(extra="forbid")
 
-    @model_validator(mode="after")
-    def validate_energy(cls, values: Self) -> Self:  # noqa
-        if values.task_exception != "null" or values.result_id == "null":
-            raise ValueError(f"The Scan failed with error {values.task_exception}")
-        return values
+    # @model_validator(mode="after")
+    # def validate_energy(cls, values: Self) -> Self:  # noqa
+    #     if values.task_exception != "null" or values.result_id == "null":
+    #         raise ValueError(f"The Scan failed with error {values.task_exception}")
+    #     return values

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,7 +93,7 @@ reference = "cachedpypi"
 
 [[package]]
 name = "as-acquisition-library"
-version = "1.0.4"
+version = "1.0.6"
 description = "Library for common devices, plans, and tools for beamline control and acquisition."
 optional = false
 python-versions = "^3.10"
@@ -115,7 +115,7 @@ standard = ["bluesky (>=1.8.2,<2.0.0)", "ophyd (>=1.7.0,<2.0.0)", "pyepics (>=3.
 type = "git"
 url = "https://bitbucket.synchrotron.org.au/scm/ec/as-acquisition-library.git"
 reference = "main"
-resolved_reference = "3965b07ac74914a479a5d127f43ec694f3ee4ea5"
+resolved_reference = "0c1eee66e959fdca5c1b3d250078762187560486"
 
 [[package]]
 name = "as-redis-signal"
@@ -139,13 +139,13 @@ resolved_reference = "87d6e5c75885aa27043ba973ee53ade93f7d1c92"
 
 [[package]]
 name = "async-timeout"
-version = "4.0.3"
+version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
-    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
 ]
 
 [package.source]
@@ -795,23 +795,23 @@ reference = "cachedpypi"
 
 [[package]]
 name = "event-model"
-version = "1.21.0"
-description = "Data model used by the bluesky ecosystem"
+version = "1.22.1"
+description = "Data model used by the bluesky ecosystem."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "event_model-1.21.0-py3-none-any.whl", hash = "sha256:365ba56644b0d49f433e8dd43b84347d46467472977444a58802f74e5f23dda9"},
-    {file = "event_model-1.21.0.tar.gz", hash = "sha256:4c0c6ce9db71fb022f38b5ee6c0c55114851dd07bdfe08a5c54bff9317ce1446"},
+    {file = "event_model-1.22.1-py3-none-any.whl", hash = "sha256:f9dd1a41ab4f09bda0de182c9d30c5c464357c6b5a699d4cd0b52e4e88cf8cff"},
+    {file = "event_model-1.22.1.tar.gz", hash = "sha256:9861c24aafb5f06a9295d43bcf9b7e071eacbf92c214b409de221f1b6470e059"},
 ]
 
 [package.dependencies]
 importlib-resources = "*"
-jsonschema = ">=3"
+jsonschema = ">=4"
 numpy = "*"
 typing-extensions = "*"
 
 [package.extras]
-dev = ["Flake8-pyproject", "black", "dask[array]", "flake8", "flake8-isort", "ipython", "matplotlib", "mypy", "numpydoc", "pipdeptree", "pre-commit", "pydantic (>=2.6)", "pydata-sphinx-theme (>=0.12)", "pytest", "pytest-cov", "sphinx", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "tox-direct", "types-mock"]
+dev = ["copier (==9.3.1)", "ipython", "matplotlib", "mypy", "myst-parser", "numpydoc", "pipdeptree", "pre-commit", "pydantic (>=2.6)", "pydata-sphinx-theme (>=0.12)", "pytest", "pytest-cov", "ruff", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "tox-direct", "types-mock"]
 
 [package.source]
 type = "legacy"
@@ -882,13 +882,13 @@ reference = "cachedpypi"
 
 [[package]]
 name = "flexparser"
-version = "0.3.1"
+version = "0.4"
 description = "Parsing made fun ... using typing."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "flexparser-0.3.1-py3-none-any.whl", hash = "sha256:2e3e2936bec1f9277f777ef77297522087d96adb09624d4fe4240fd56885c013"},
-    {file = "flexparser-0.3.1.tar.gz", hash = "sha256:36f795d82e50f5c9ae2fde1c33f21f88922fdd67b7629550a3cc4d0b40a66856"},
+    {file = "flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846"},
+    {file = "flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2"},
 ]
 
 [package.dependencies]
@@ -2328,13 +2328,13 @@ reference = "cachedpypi"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.6.0"
+version = "2.6.1"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_settings-2.6.0-py3-none-any.whl", hash = "sha256:4a819166f119b74d7f8c765196b165f95cc7487ce58ea27dec8a5a26be0970e0"},
-    {file = "pydantic_settings-2.6.0.tar.gz", hash = "sha256:44a1804abffac9e6a30372bb45f6cafab945ef5af25e66b1c634c01dd39e0188"},
+    {file = "pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87"},
+    {file = "pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0"},
 ]
 
 [package.dependencies]
@@ -2641,13 +2641,13 @@ reference = "cachedpypi"
 
 [[package]]
 name = "redis"
-version = "5.1.1"
+version = "5.2.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "redis-5.1.1-py3-none-any.whl", hash = "sha256:f8ea06b7482a668c6475ae202ed8d9bcaa409f6e87fb77ed1043d912afd62e24"},
-    {file = "redis-5.1.1.tar.gz", hash = "sha256:f6c997521fedbae53387307c5d0bf784d9acc28d9f1d058abeac566ec4dbed72"},
+    {file = "redis-5.2.0-py3-none-any.whl", hash = "sha256:ae174f2bb3b1bf2b09d54bf3e51fbc1469cf6c10aa03e21141f51969801a7897"},
+    {file = "redis-5.2.0.tar.gz", hash = "sha256:0b1087665a771b1ff2e003aa5bdd354f15a70c9e25d5a7dbf9c722c16528a7b0"},
 ]
 
 [package.dependencies]
@@ -2710,114 +2710,101 @@ reference = "cachedpypi"
 
 [[package]]
 name = "rpds-py"
-version = "0.20.0"
+version = "0.21.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "rpds_py-0.20.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3ad0fda1635f8439cde85c700f964b23ed5fc2d28016b32b9ee5fe30da5c84e2"},
-    {file = "rpds_py-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9bb4a0d90fdb03437c109a17eade42dfbf6190408f29b2744114d11586611d6f"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6377e647bbfd0a0b159fe557f2c6c602c159fc752fa316572f012fc0bf67150"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb851b7df9dda52dc1415ebee12362047ce771fc36914586b2e9fcbd7d293b3e"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e0f80b739e5a8f54837be5d5c924483996b603d5502bfff79bf33da06164ee2"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a8c94dad2e45324fc74dce25e1645d4d14df9a4e54a30fa0ae8bad9a63928e3"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8e604fe73ba048c06085beaf51147eaec7df856824bfe7b98657cf436623daf"},
-    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:df3de6b7726b52966edf29663e57306b23ef775faf0ac01a3e9f4012a24a4140"},
-    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf258ede5bc22a45c8e726b29835b9303c285ab46fc7c3a4cc770736b5304c9f"},
-    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:55fea87029cded5df854ca7e192ec7bdb7ecd1d9a3f63d5c4eb09148acf4a7ce"},
-    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ae94bd0b2f02c28e199e9bc51485d0c5601f58780636185660f86bf80c89af94"},
-    {file = "rpds_py-0.20.0-cp310-none-win32.whl", hash = "sha256:28527c685f237c05445efec62426d285e47a58fb05ba0090a4340b73ecda6dee"},
-    {file = "rpds_py-0.20.0-cp310-none-win_amd64.whl", hash = "sha256:238a2d5b1cad28cdc6ed15faf93a998336eb041c4e440dd7f902528b8891b399"},
-    {file = "rpds_py-0.20.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ac2f4f7a98934c2ed6505aead07b979e6f999389f16b714448fb39bbaa86a489"},
-    {file = "rpds_py-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:220002c1b846db9afd83371d08d239fdc865e8f8c5795bbaec20916a76db3318"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d7919548df3f25374a1f5d01fbcd38dacab338ef5f33e044744b5c36729c8db"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:758406267907b3781beee0f0edfe4a179fbd97c0be2e9b1154d7f0a1279cf8e5"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d61339e9f84a3f0767b1995adfb171a0d00a1185192718a17af6e124728e0f5"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1259c7b3705ac0a0bd38197565a5d603218591d3f6cee6e614e380b6ba61c6f6"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c1dc0f53856b9cc9a0ccca0a7cc61d3d20a7088201c0937f3f4048c1718a209"},
-    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7e60cb630f674a31f0368ed32b2a6b4331b8350d67de53c0359992444b116dd3"},
-    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbe982f38565bb50cb7fb061ebf762c2f254ca3d8c20d4006878766e84266272"},
-    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:514b3293b64187172bc77c8fb0cdae26981618021053b30d8371c3a902d4d5ad"},
-    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0a26ffe9d4dd35e4dfdd1e71f46401cff0181c75ac174711ccff0459135fa58"},
-    {file = "rpds_py-0.20.0-cp311-none-win32.whl", hash = "sha256:89c19a494bf3ad08c1da49445cc5d13d8fefc265f48ee7e7556839acdacf69d0"},
-    {file = "rpds_py-0.20.0-cp311-none-win_amd64.whl", hash = "sha256:c638144ce971df84650d3ed0096e2ae7af8e62ecbbb7b201c8935c370df00a2c"},
-    {file = "rpds_py-0.20.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a84ab91cbe7aab97f7446652d0ed37d35b68a465aeef8fc41932a9d7eee2c1a6"},
-    {file = "rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:56e27147a5a4c2c21633ff8475d185734c0e4befd1c989b5b95a5d0db699b21b"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2580b0c34583b85efec8c5c5ec9edf2dfe817330cc882ee972ae650e7b5ef739"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b80d4a7900cf6b66bb9cee5c352b2d708e29e5a37fe9bf784fa97fc11504bf6c"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50eccbf054e62a7b2209b28dc7a22d6254860209d6753e6b78cfaeb0075d7bee"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49a8063ea4296b3a7e81a5dfb8f7b2d73f0b1c20c2af401fb0cdf22e14711a96"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea438162a9fcbee3ecf36c23e6c68237479f89f962f82dae83dc15feeceb37e4"},
-    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18d7585c463087bddcfa74c2ba267339f14f2515158ac4db30b1f9cbdb62c8ef"},
-    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d4c7d1a051eeb39f5c9547e82ea27cbcc28338482242e3e0b7768033cb083821"},
-    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4df1e3b3bec320790f699890d41c59d250f6beda159ea3c44c3f5bac1976940"},
-    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2cf126d33a91ee6eedc7f3197b53e87a2acdac63602c0f03a02dd69e4b138174"},
-    {file = "rpds_py-0.20.0-cp312-none-win32.whl", hash = "sha256:8bc7690f7caee50b04a79bf017a8d020c1f48c2a1077ffe172abec59870f1139"},
-    {file = "rpds_py-0.20.0-cp312-none-win_amd64.whl", hash = "sha256:0e13e6952ef264c40587d510ad676a988df19adea20444c2b295e536457bc585"},
-    {file = "rpds_py-0.20.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:aa9a0521aeca7d4941499a73ad7d4f8ffa3d1affc50b9ea11d992cd7eff18a29"},
-    {file = "rpds_py-0.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a1f1d51eccb7e6c32ae89243cb352389228ea62f89cd80823ea7dd1b98e0b91"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a86a9b96070674fc88b6f9f71a97d2c1d3e5165574615d1f9168ecba4cecb24"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c8ef2ebf76df43f5750b46851ed1cdf8f109d7787ca40035fe19fbdc1acc5a7"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b74b25f024b421d5859d156750ea9a65651793d51b76a2e9238c05c9d5f203a9"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57eb94a8c16ab08fef6404301c38318e2c5a32216bf5de453e2714c964c125c8"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1940dae14e715e2e02dfd5b0f64a52e8374a517a1e531ad9412319dc3ac7879"},
-    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d20277fd62e1b992a50c43f13fbe13277a31f8c9f70d59759c88f644d66c619f"},
-    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:06db23d43f26478303e954c34c75182356ca9aa7797d22c5345b16871ab9c45c"},
-    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b2a5db5397d82fa847e4c624b0c98fe59d2d9b7cf0ce6de09e4d2e80f8f5b3f2"},
-    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a35df9f5548fd79cb2f52d27182108c3e6641a4feb0f39067911bf2adaa3e57"},
-    {file = "rpds_py-0.20.0-cp313-none-win32.whl", hash = "sha256:fd2d84f40633bc475ef2d5490b9c19543fbf18596dcb1b291e3a12ea5d722f7a"},
-    {file = "rpds_py-0.20.0-cp313-none-win_amd64.whl", hash = "sha256:9bc2d153989e3216b0559251b0c260cfd168ec78b1fac33dd485750a228db5a2"},
-    {file = "rpds_py-0.20.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:f2fbf7db2012d4876fb0d66b5b9ba6591197b0f165db8d99371d976546472a24"},
-    {file = "rpds_py-0.20.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1e5f3cd7397c8f86c8cc72d5a791071431c108edd79872cdd96e00abd8497d29"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce9845054c13696f7af7f2b353e6b4f676dab1b4b215d7fe5e05c6f8bb06f965"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c3e130fd0ec56cb76eb49ef52faead8ff09d13f4527e9b0c400307ff72b408e1"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b16aa0107ecb512b568244ef461f27697164d9a68d8b35090e9b0c1c8b27752"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa7f429242aae2947246587d2964fad750b79e8c233a2367f71b554e9447949c"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af0fc424a5842a11e28956e69395fbbeab2c97c42253169d87e90aac2886d751"},
-    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b8c00a3b1e70c1d3891f0db1b05292747f0dbcfb49c43f9244d04c70fbc40eb8"},
-    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:40ce74fc86ee4645d0a225498d091d8bc61f39b709ebef8204cb8b5a464d3c0e"},
-    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4fe84294c7019456e56d93e8ababdad5a329cd25975be749c3f5f558abb48253"},
-    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:338ca4539aad4ce70a656e5187a3a31c5204f261aef9f6ab50e50bcdffaf050a"},
-    {file = "rpds_py-0.20.0-cp38-none-win32.whl", hash = "sha256:54b43a2b07db18314669092bb2de584524d1ef414588780261e31e85846c26a5"},
-    {file = "rpds_py-0.20.0-cp38-none-win_amd64.whl", hash = "sha256:a1862d2d7ce1674cffa6d186d53ca95c6e17ed2b06b3f4c476173565c862d232"},
-    {file = "rpds_py-0.20.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:3fde368e9140312b6e8b6c09fb9f8c8c2f00999d1823403ae90cc00480221b22"},
-    {file = "rpds_py-0.20.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9824fb430c9cf9af743cf7aaf6707bf14323fb51ee74425c380f4c846ea70789"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11ef6ce74616342888b69878d45e9f779b95d4bd48b382a229fe624a409b72c5"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c52d3f2f82b763a24ef52f5d24358553e8403ce05f893b5347098014f2d9eff2"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d35cef91e59ebbeaa45214861874bc6f19eb35de96db73e467a8358d701a96c"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d72278a30111e5b5525c1dd96120d9e958464316f55adb030433ea905866f4de"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4c29cbbba378759ac5786730d1c3cb4ec6f8ababf5c42a9ce303dc4b3d08cda"},
-    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6632f2d04f15d1bd6fe0eedd3b86d9061b836ddca4c03d5cf5c7e9e6b7c14580"},
-    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d0b67d87bb45ed1cd020e8fbf2307d449b68abc45402fe1a4ac9e46c3c8b192b"},
-    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec31a99ca63bf3cd7f1a5ac9fe95c5e2d060d3c768a09bc1d16e235840861420"},
-    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:22e6c9976e38f4d8c4a63bd8a8edac5307dffd3ee7e6026d97f3cc3a2dc02a0b"},
-    {file = "rpds_py-0.20.0-cp39-none-win32.whl", hash = "sha256:569b3ea770c2717b730b61998b6c54996adee3cef69fc28d444f3e7920313cf7"},
-    {file = "rpds_py-0.20.0-cp39-none-win_amd64.whl", hash = "sha256:e6900ecdd50ce0facf703f7a00df12374b74bbc8ad9fe0f6559947fb20f82364"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:617c7357272c67696fd052811e352ac54ed1d9b49ab370261a80d3b6ce385045"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9426133526f69fcaba6e42146b4e12d6bc6c839b8b555097020e2b78ce908dcc"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:deb62214c42a261cb3eb04d474f7155279c1a8a8c30ac89b7dcb1721d92c3c02"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcaeb7b57f1a1e071ebd748984359fef83ecb026325b9d4ca847c95bc7311c92"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d454b8749b4bd70dd0a79f428731ee263fa6995f83ccb8bada706e8d1d3ff89d"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d807dc2051abe041b6649681dce568f8e10668e3c1c6543ebae58f2d7e617855"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3c20f0ddeb6e29126d45f89206b8291352b8c5b44384e78a6499d68b52ae511"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b7f19250ceef892adf27f0399b9e5afad019288e9be756d6919cb58892129f51"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:4f1ed4749a08379555cebf4650453f14452eaa9c43d0a95c49db50c18b7da075"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:dcedf0b42bcb4cfff4101d7771a10532415a6106062f005ab97d1d0ab5681c60"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:39ed0d010457a78f54090fafb5d108501b5aa5604cc22408fc1c0c77eac14344"},
-    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:bb273176be34a746bdac0b0d7e4e2c467323d13640b736c4c477881a3220a989"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f918a1a130a6dfe1d7fe0f105064141342e7dd1611f2e6a21cd2f5c8cb1cfb3e"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f60012a73aa396be721558caa3a6fd49b3dd0033d1675c6d59c4502e870fcf0c"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d2b1ad682a3dfda2a4e8ad8572f3100f95fad98cb99faf37ff0ddfe9cbf9d03"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:614fdafe9f5f19c63ea02817fa4861c606a59a604a77c8cdef5aa01d28b97921"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fa518bcd7600c584bf42e6617ee8132869e877db2f76bcdc281ec6a4113a53ab"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0475242f447cc6cb8a9dd486d68b2ef7fbee84427124c232bff5f63b1fe11e5"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f90a4cd061914a60bd51c68bcb4357086991bd0bb93d8aa66a6da7701370708f"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:def7400461c3a3f26e49078302e1c1b38f6752342c77e3cf72ce91ca69fb1bc1"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:65794e4048ee837494aea3c21a28ad5fc080994dfba5b036cf84de37f7ad5074"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:faefcc78f53a88f3076b7f8be0a8f8d35133a3ecf7f3770895c25f8813460f08"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5b4f105deeffa28bbcdff6c49b34e74903139afa690e35d2d9e3c2c2fba18cec"},
-    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fdfc3a892927458d98f3d55428ae46b921d1f7543b89382fdb483f5640daaec8"},
-    {file = "rpds_py-0.20.0.tar.gz", hash = "sha256:d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121"},
+    {file = "rpds_py-0.21.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a017f813f24b9df929674d0332a374d40d7f0162b326562daae8066b502d0590"},
+    {file = "rpds_py-0.21.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:20cc1ed0bcc86d8e1a7e968cce15be45178fd16e2ff656a243145e0b439bd250"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad116dda078d0bc4886cb7840e19811562acdc7a8e296ea6ec37e70326c1b41c"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:808f1ac7cf3b44f81c9475475ceb221f982ef548e44e024ad5f9e7060649540e"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de552f4a1916e520f2703ec474d2b4d3f86d41f353e7680b597512ffe7eac5d0"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efec946f331349dfc4ae9d0e034c263ddde19414fe5128580f512619abed05f1"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b80b4690bbff51a034bfde9c9f6bf9357f0a8c61f548942b80f7b66356508bf5"},
+    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085ed25baac88953d4283e5b5bd094b155075bb40d07c29c4f073e10623f9f2e"},
+    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:daa8efac2a1273eed2354397a51216ae1e198ecbce9036fba4e7610b308b6153"},
+    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:95a5bad1ac8a5c77b4e658671642e4af3707f095d2b78a1fdd08af0dfb647624"},
+    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3e53861b29a13d5b70116ea4230b5f0f3547b2c222c5daa090eb7c9c82d7f664"},
+    {file = "rpds_py-0.21.0-cp310-none-win32.whl", hash = "sha256:ea3a6ac4d74820c98fcc9da4a57847ad2cc36475a8bd9683f32ab6d47a2bd682"},
+    {file = "rpds_py-0.21.0-cp310-none-win_amd64.whl", hash = "sha256:b8f107395f2f1d151181880b69a2869c69e87ec079c49c0016ab96860b6acbe5"},
+    {file = "rpds_py-0.21.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5555db3e618a77034954b9dc547eae94166391a98eb867905ec8fcbce1308d95"},
+    {file = "rpds_py-0.21.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97ef67d9bbc3e15584c2f3c74bcf064af36336c10d2e21a2131e123ce0f924c9"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ab2c2a26d2f69cdf833174f4d9d86118edc781ad9a8fa13970b527bf8236027"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4e8921a259f54bfbc755c5bbd60c82bb2339ae0324163f32868f63f0ebb873d9"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a7ff941004d74d55a47f916afc38494bd1cfd4b53c482b77c03147c91ac0ac3"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5145282a7cd2ac16ea0dc46b82167754d5e103a05614b724457cffe614f25bd8"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de609a6f1b682f70bb7163da745ee815d8f230d97276db049ab447767466a09d"},
+    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:40c91c6e34cf016fa8e6b59d75e3dbe354830777fcfd74c58b279dceb7975b75"},
+    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d2132377f9deef0c4db89e65e8bb28644ff75a18df5293e132a8d67748397b9f"},
+    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0a9e0759e7be10109645a9fddaaad0619d58c9bf30a3f248a2ea57a7c417173a"},
+    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e20da3957bdf7824afdd4b6eeb29510e83e026473e04952dca565170cd1ecc8"},
+    {file = "rpds_py-0.21.0-cp311-none-win32.whl", hash = "sha256:f71009b0d5e94c0e86533c0b27ed7cacc1239cb51c178fd239c3cfefefb0400a"},
+    {file = "rpds_py-0.21.0-cp311-none-win_amd64.whl", hash = "sha256:e168afe6bf6ab7ab46c8c375606298784ecbe3ba31c0980b7dcbb9631dcba97e"},
+    {file = "rpds_py-0.21.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:30b912c965b2aa76ba5168fd610087bad7fcde47f0a8367ee8f1876086ee6d1d"},
+    {file = "rpds_py-0.21.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ca9989d5d9b1b300bc18e1801c67b9f6d2c66b8fd9621b36072ed1df2c977f72"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f54e7106f0001244a5f4cf810ba8d3f9c542e2730821b16e969d6887b664266"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fed5dfefdf384d6fe975cc026886aece4f292feaf69d0eeb716cfd3c5a4dd8be"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:590ef88db231c9c1eece44dcfefd7515d8bf0d986d64d0caf06a81998a9e8cab"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f983e4c2f603c95dde63df633eec42955508eefd8d0f0e6d236d31a044c882d7"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b229ce052ddf1a01c67d68166c19cb004fb3612424921b81c46e7ea7ccf7c3bf"},
+    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ebf64e281a06c904a7636781d2e973d1f0926a5b8b480ac658dc0f556e7779f4"},
+    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:998a8080c4495e4f72132f3d66ff91f5997d799e86cec6ee05342f8f3cda7dca"},
+    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:98486337f7b4f3c324ab402e83453e25bb844f44418c066623db88e4c56b7c7b"},
+    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a78d8b634c9df7f8d175451cfeac3810a702ccb85f98ec95797fa98b942cea11"},
+    {file = "rpds_py-0.21.0-cp312-none-win32.whl", hash = "sha256:a58ce66847711c4aa2ecfcfaff04cb0327f907fead8945ffc47d9407f41ff952"},
+    {file = "rpds_py-0.21.0-cp312-none-win_amd64.whl", hash = "sha256:e860f065cc4ea6f256d6f411aba4b1251255366e48e972f8a347cf88077b24fd"},
+    {file = "rpds_py-0.21.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ee4eafd77cc98d355a0d02f263efc0d3ae3ce4a7c24740010a8b4012bbb24937"},
+    {file = "rpds_py-0.21.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:688c93b77e468d72579351a84b95f976bd7b3e84aa6686be6497045ba84be560"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c38dbf31c57032667dd5a2f0568ccde66e868e8f78d5a0d27dcc56d70f3fcd3b"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2d6129137f43f7fa02d41542ffff4871d4aefa724a5fe38e2c31a4e0fd343fb0"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:520ed8b99b0bf86a176271f6fe23024323862ac674b1ce5b02a72bfeff3fff44"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaeb25ccfb9b9014a10eaf70904ebf3f79faaa8e60e99e19eef9f478651b9b74"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af04ac89c738e0f0f1b913918024c3eab6e3ace989518ea838807177d38a2e94"},
+    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b9b76e2afd585803c53c5b29e992ecd183f68285b62fe2668383a18e74abe7a3"},
+    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5afb5efde74c54724e1a01118c6e5c15e54e642c42a1ba588ab1f03544ac8c7a"},
+    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:52c041802a6efa625ea18027a0723676a778869481d16803481ef6cc02ea8cb3"},
+    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee1e4fc267b437bb89990b2f2abf6c25765b89b72dd4a11e21934df449e0c976"},
+    {file = "rpds_py-0.21.0-cp313-none-win32.whl", hash = "sha256:0c025820b78817db6a76413fff6866790786c38f95ea3f3d3c93dbb73b632202"},
+    {file = "rpds_py-0.21.0-cp313-none-win_amd64.whl", hash = "sha256:320c808df533695326610a1b6a0a6e98f033e49de55d7dc36a13c8a30cfa756e"},
+    {file = "rpds_py-0.21.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:2c51d99c30091f72a3c5d126fad26236c3f75716b8b5e5cf8effb18889ced928"},
+    {file = "rpds_py-0.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cbd7504a10b0955ea287114f003b7ad62330c9e65ba012c6223dba646f6ffd05"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dcc4949be728ede49e6244eabd04064336012b37f5c2200e8ec8eb2988b209c"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f414da5c51bf350e4b7960644617c130140423882305f7574b6cf65a3081cecb"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9afe42102b40007f588666bc7de82451e10c6788f6f70984629db193849dced1"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b929c2bb6e29ab31f12a1117c39f7e6d6450419ab7464a4ea9b0b417174f044"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8404b3717da03cbf773a1d275d01fec84ea007754ed380f63dfc24fb76ce4592"},
+    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e12bb09678f38b7597b8346983d2323a6482dcd59e423d9448108c1be37cac9d"},
+    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:58a0e345be4b18e6b8501d3b0aa540dad90caeed814c515e5206bb2ec26736fd"},
+    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c3761f62fcfccf0864cc4665b6e7c3f0c626f0380b41b8bd1ce322103fa3ef87"},
+    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c2b2f71c6ad6c2e4fc9ed9401080badd1469fa9889657ec3abea42a3d6b2e1ed"},
+    {file = "rpds_py-0.21.0-cp39-none-win32.whl", hash = "sha256:b21747f79f360e790525e6f6438c7569ddbfb1b3197b9e65043f25c3c9b489d8"},
+    {file = "rpds_py-0.21.0-cp39-none-win_amd64.whl", hash = "sha256:0626238a43152918f9e72ede9a3b6ccc9e299adc8ade0d67c5e142d564c9a83d"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6b4ef7725386dc0762857097f6b7266a6cdd62bfd209664da6712cb26acef035"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:6bc0e697d4d79ab1aacbf20ee5f0df80359ecf55db33ff41481cf3e24f206919"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da52d62a96e61c1c444f3998c434e8b263c384f6d68aca8274d2e08d1906325c"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98e4fe5db40db87ce1c65031463a760ec7906ab230ad2249b4572c2fc3ef1f9f"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30bdc973f10d28e0337f71d202ff29345320f8bc49a31c90e6c257e1ccef4333"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:faa5e8496c530f9c71f2b4e1c49758b06e5f4055e17144906245c99fa6d45356"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32eb88c30b6a4f0605508023b7141d043a79b14acb3b969aa0b4f99b25bc7d4a"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a89a8ce9e4e75aeb7fa5d8ad0f3fecdee813802592f4f46a15754dcb2fd6b061"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:241e6c125568493f553c3d0fdbb38c74babf54b45cef86439d4cd97ff8feb34d"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:3b766a9f57663396e4f34f5140b3595b233a7b146e94777b97a8413a1da1be18"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:af4a644bf890f56e41e74be7d34e9511e4954894d544ec6b8efe1e21a1a8da6c"},
+    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3e30a69a706e8ea20444b98a49f386c17b26f860aa9245329bab0851ed100677"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:031819f906bb146561af051c7cef4ba2003d28cff07efacef59da973ff7969ba"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:b876f2bc27ab5954e2fd88890c071bd0ed18b9c50f6ec3de3c50a5ece612f7a6"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc5695c321e518d9f03b7ea6abb5ea3af4567766f9852ad1560f501b17588c7b"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4de1da871b5c0fd5537b26a6fc6814c3cc05cabe0c941db6e9044ffbb12f04a"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:878f6fea96621fda5303a2867887686d7a198d9e0f8a40be100a63f5d60c88c9"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8eeec67590e94189f434c6d11c426892e396ae59e4801d17a93ac96b8c02a6c"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ff2eba7f6c0cb523d7e9cff0903f2fe1feff8f0b2ceb6bd71c0e20a4dcee271"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a429b99337062877d7875e4ff1a51fe788424d522bd64a8c0a20ef3021fdb6ed"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:d167e4dbbdac48bd58893c7e446684ad5d425b407f9336e04ab52e8b9194e2ed"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:4eb2de8a147ffe0626bfdc275fc6563aa7bf4b6db59cf0d44f0ccd6ca625a24e"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e78868e98f34f34a88e23ee9ccaeeec460e4eaf6db16d51d7a9b883e5e785a5e"},
+    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4991ca61656e3160cdaca4851151fd3f4a92e9eba5c7a530ab030d6aee96ec89"},
+    {file = "rpds_py-0.21.0.tar.gz", hash = "sha256:ed6378c9d66d0de903763e7706383d60c33829581f0adff47b6535f1802fa6db"},
 ]
 
 [package.source]
@@ -2882,23 +2869,23 @@ reference = "cachedpypi"
 
 [[package]]
 name = "setuptools"
-version = "75.2.0"
+version = "75.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
-    {file = "setuptools-75.2.0.tar.gz", hash = "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec"},
+    {file = "setuptools-75.3.0-py3-none-any.whl", hash = "sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd"},
+    {file = "setuptools-75.3.0.tar.gz", hash = "sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686"},
 ]
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.5.2)"]
-core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.collections", "jaraco.functools", "jaraco.text (>=3.7)", "more-itertools", "more-itertools (>=8.8)", "packaging", "packaging (>=24)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.11.*)", "pytest-mypy"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12.*)", "pytest-mypy"]
 
 [package.source]
 type = "legacy"
@@ -3223,13 +3210,13 @@ reference = "cachedpypi"
 
 [[package]]
 name = "tqdm"
-version = "4.66.5"
+version = "4.67.0"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
-    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
+    {file = "tqdm-4.67.0-py3-none-any.whl", hash = "sha256:0cd8af9d56911acab92182e88d763100d4788bdf421d251616040cc4d44863be"},
+    {file = "tqdm-4.67.0.tar.gz", hash = "sha256:fe5a6f95e6fe0b9755e9469b77b9c3cf850048224ecaa8293d7d2d31f97d869a"},
 ]
 
 [package.dependencies]
@@ -3237,6 +3224,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
 dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
@@ -3302,13 +3290,13 @@ reference = "cachedpypi"
 
 [[package]]
 name = "virtualenv"
-version = "20.27.0"
+version = "20.27.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.27.0-py3-none-any.whl", hash = "sha256:44a72c29cceb0ee08f300b314848c86e57bf8d1f13107a5e671fb9274138d655"},
-    {file = "virtualenv-20.27.0.tar.gz", hash = "sha256:2ca56a68ed615b8fe4326d11a0dca5dfbe8fd68510fb6c6349163bed3c15f2b2"},
+    {file = "virtualenv-20.27.1-py3-none-any.whl", hash = "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4"},
+    {file = "virtualenv-20.27.1.tar.gz", hash = "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mx3-beamline-library"
-version = "1.2.1"
+version = "1.2.2"
 description = "Ophyd devices and bluesky plans."
 authors = ["Stephen Mudie <stephenm@ansto.gov.au>"]
 


### PR DESCRIPTION
* Replace exposure time with md3_alignment_y_speed when running tray grid scans
* When screening is done in trays, the start angle is automatically set to 91 - scan_range/2 or 270 - scan_range / 2 (depending on the tray type).
* After tray screening finishes, omega is automatically returned to 91 degrees, or 270 degrees depending on the start angle