### PR TITLE
Udc and mxcube scans improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
     - id: black
       name: Black
@@ -44,7 +44,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     - id: flake8
       name: Flake8

--- a/mx3_beamline_library/credentials.py
+++ b/mx3_beamline_library/credentials.py
@@ -1,2 +1,2 @@
-""" This is a place holder for credential management.
-In production K8S secrects will be used. """
+"""This is a place holder for credential management.
+In production K8S secrects will be used."""

--- a/mx3_beamline_library/devices/__init__.py
+++ b/mx3_beamline_library/devices/__init__.py
@@ -1,12 +1,12 @@
-""" Files in the top level of ``devices`` contain the instantiation of devices. The names of
-    these files is at the discretion of Scientific Computing and Beamline Staff. However, some
-    suggested files appear in the template. Do not prepend these file names with the beamline
-    name/abbreviation.
+"""Files in the top level of ``devices`` contain the instantiation of devices. The names of
+these files is at the discretion of Scientific Computing and Beamline Staff. However, some
+suggested files appear in the template. Do not prepend these file names with the beamline
+name/abbreviation.
 
-    Imports are conditional on an environment variable ``BL_ACTIVE``.
-    The real device modules will *not* be imported unless this is set to True.
-    If present the sim device modules will be imported
-    if not ``True``.
+Imports are conditional on an environment variable ``BL_ACTIVE``.
+The real device modules will *not* be imported unless this is set to True.
+If present the sim device modules will be imported
+if not ``True``.
 """
 
 from __future__ import annotations

--- a/mx3_beamline_library/devices/classes/__init__.py
+++ b/mx3_beamline_library/devices/classes/__init__.py
@@ -1,4 +1,4 @@
-""" This directory contains class definitions for devices specific to this beamline. """
+"""This directory contains class definitions for devices specific to this beamline."""
 
 from typing import Mapping
 

--- a/mx3_beamline_library/devices/classes/detectors.py
+++ b/mx3_beamline_library/devices/classes/detectors.py
@@ -1,4 +1,4 @@
-""" Beamline detector definition """
+"""Beamline detector definition"""
 
 import logging
 import os

--- a/mx3_beamline_library/devices/classes/md3/ClientFactory.py
+++ b/mx3_beamline_library/devices/classes/md3/ClientFactory.py
@@ -1,6 +1,6 @@
 """
-  This code is provided AS IS for example purpose and testing MD Device Server
-  ARINAX Sep. 2021
+This code is provided AS IS for example purpose and testing MD Device Server
+ARINAX Sep. 2021
 """
 
 from .ExportClient import ExporterClientFactory

--- a/mx3_beamline_library/devices/classes/md3/Command/embl/ExporterClient.py
+++ b/mx3_beamline_library/devices/classes/md3/Command/embl/ExporterClient.py
@@ -1,10 +1,10 @@
 """
-  Project: JLib
+Project: JLib
 
-  Date       Author    Changes
-  01.07.09   Gobbo     Created
+Date       Author    Changes
+01.07.09   Gobbo     Created
 
-  Copyright 2009 by European Molecular Biology Laboratory - Grenoble
+Copyright 2009 by European Molecular Biology Laboratory - Grenoble
 """
 
 import logging

--- a/mx3_beamline_library/devices/classes/md3/Command/embl/StandardClient.py
+++ b/mx3_beamline_library/devices/classes/md3/Command/embl/StandardClient.py
@@ -1,10 +1,10 @@
 """
-  Project: JLib
+Project: JLib
 
-  Date       Author    Changes
-  01.07.09   Gobbo     Created
+Date       Author    Changes
+01.07.09   Gobbo     Created
 
-  Copyright 2009 by European Molecular Biology Laboratory - Grenoble
+Copyright 2009 by European Molecular Biology Laboratory - Grenoble
 """
 
 # from gevent.event import Event

--- a/mx3_beamline_library/devices/classes/md3/ExportClient.py
+++ b/mx3_beamline_library/devices/classes/md3/ExportClient.py
@@ -1,7 +1,7 @@
 """
-  This code derived from EMBL code is provided AS IS for example purpose
-  and testing MD Device Server
-  ARINAX Sep. 2021
+This code derived from EMBL code is provided AS IS for example purpose
+and testing MD Device Server
+ARINAX Sep. 2021
 """
 
 try:

--- a/mx3_beamline_library/devices/classes/md3/GenericClient.py
+++ b/mx3_beamline_library/devices/classes/md3/GenericClient.py
@@ -1,6 +1,6 @@
 """
-  This code is provided AS IS for example purpose and testing MD Device Server
-  ARINAX Sep. 2021
+This code is provided AS IS for example purpose and testing MD Device Server
+ARINAX Sep. 2021
 """
 
 import re

--- a/mx3_beamline_library/devices/classes/md3/Logger.py
+++ b/mx3_beamline_library/devices/classes/md3/Logger.py
@@ -1,6 +1,6 @@
 """
-  This code is provided AS IS for example purpose and testing MD Device Server
-  ARINAX Sep. 2021
+This code is provided AS IS for example purpose and testing MD Device Server
+ARINAX Sep. 2021
 """
 
 import logging

--- a/mx3_beamline_library/devices/classes/motors.py
+++ b/mx3_beamline_library/devices/classes/motors.py
@@ -1,4 +1,4 @@
-""" Motor Definitions """
+"""Motor Definitions"""
 
 import logging
 from functools import cached_property

--- a/mx3_beamline_library/devices/detectors.py
+++ b/mx3_beamline_library/devices/detectors.py
@@ -1,4 +1,4 @@
-""" Beamline detectors """
+"""Beamline detectors"""
 
 from ..config import MD3_DB, MD3_HOST, MD3_PORT, SIMPLON_API
 from .classes.detectors import BlackFlyCam, DectrisDetector, MDRedisCam

--- a/mx3_beamline_library/devices/motors.py
+++ b/mx3_beamline_library/devices/motors.py
@@ -1,4 +1,4 @@
-""" Motor configuration and instantiation. """
+"""Motor configuration and instantiation."""
 
 from ophyd import EpicsSignalRO
 

--- a/mx3_beamline_library/devices/sim/__init__.py
+++ b/mx3_beamline_library/devices/sim/__init__.py
@@ -1,7 +1,7 @@
-""" This directory contains simulated device instation specific to this beamline.
-    Filenames should match the real device instantion file names. This simulation
-    could be achieved via simulation at the ophyd layer or simulated IOCs
-    (e.g., with caproto) external to the beamline library. Tools for automated
-    mocking/generation of simulated devices could be explored, or methods for
-    switching between mock and real PVs for the case of simulated IOCs.
+"""This directory contains simulated device instation specific to this beamline.
+Filenames should match the real device instantion file names. This simulation
+could be achieved via simulation at the ophyd layer or simulated IOCs
+(e.g., with caproto) external to the beamline library. Tools for automated
+mocking/generation of simulated devices could be explored, or methods for
+switching between mock and real PVs for the case of simulated IOCs.
 """

--- a/mx3_beamline_library/devices/sim/classes/__init__.py
+++ b/mx3_beamline_library/devices/sim/classes/__init__.py
@@ -1,4 +1,4 @@
-""" This directory contains sim class definitions of devices specific to this beamline. """
+"""This directory contains sim class definitions of devices specific to this beamline."""
 
 from typing import Mapping
 

--- a/mx3_beamline_library/devices/sim/classes/motors.py
+++ b/mx3_beamline_library/devices/sim/classes/motors.py
@@ -1,4 +1,4 @@
-""" Simulated motor definitions specific to this beamline. """
+"""Simulated motor definitions specific to this beamline."""
 
 import threading
 import time

--- a/mx3_beamline_library/devices/sim/motors.py
+++ b/mx3_beamline_library/devices/sim/motors.py
@@ -1,4 +1,4 @@
-""" Simulated motor configuration and instantiation. """
+"""Simulated motor configuration and instantiation."""
 
 from ophyd import Signal
 

--- a/mx3_beamline_library/paths.py
+++ b/mx3_beamline_library/paths.py
@@ -1,6 +1,6 @@
-""" File for storing 'path' information. This can be filesystem paths and URLs.
-    Some filesystem path utilities are being developed and maybe referenced
-    here in future versions.
+"""File for storing 'path' information. This can be filesystem paths and URLs.
+Some filesystem path utilities are being developed and maybe referenced
+here in future versions.
 """
 
 from pathlib import Path

--- a/mx3_beamline_library/plans/__init__.py
+++ b/mx3_beamline_library/plans/__init__.py
@@ -1,1 +1,1 @@
-""" The plan directory contains  """
+"""The plan directory contains"""

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -161,6 +161,10 @@ def _md3_scan(
                     f"or (250,290). Current value is {omega_position}"
                 )
     else:
+        # Save the current position so that the MD3 does not change
+        # the current position if the MD3 phase is changed
+        md3.save_centring_position()
+
         if not tray_scan:
             initial_omega = md3.omega.position
         else:

--- a/mx3_beamline_library/plans/optical_centering.py
+++ b/mx3_beamline_library/plans/optical_centering.py
@@ -1039,7 +1039,9 @@ class OpticalCentering:
             block_size=self.md3_cam_block_size,
             adaptive_constant=self.md3_cam_adaptive_constant,
         )
-        rectangle_coordinates = edge_detection.fit_rectangle()
+        # TODO: determine experimentally the optimal value of
+        # height_scale_factor
+        rectangle_coordinates = edge_detection.fit_rectangle(height_scale_factor=2)
 
         if self.plot:
             edge_detection.plot_raster_grid(

--- a/mx3_beamline_library/schemas/crystal_finder.py
+++ b/mx3_beamline_library/schemas/crystal_finder.py
@@ -79,6 +79,7 @@ class MaximumNumberOfSpots(BaseModel):
 
 class CrystalVolume(BaseModel):
     "Crystal Volume model in micrometers"
+
     width: float = Field(description="Width of the crystal in micrometers")
     height: float = Field(description="Height of the crystal in micrometers")
     depth: float = Field(description="Depth of the crystal in micrometers")

--- a/mx3_beamline_library/schemas/optical_centering.py
+++ b/mx3_beamline_library/schemas/optical_centering.py
@@ -7,6 +7,7 @@ from .xray_centering import RasterGridCoordinates
 
 class CenteredLoopMotorCoordinates(BaseModel):
     "Position of the MD3 motors corresponding to an aligned loop (mm)"
+
     alignment_x: float
     alignment_y: float
     alignment_z: float

--- a/mx3_beamline_library/science/optical_and_loop_centering/loop_edge_detection.py
+++ b/mx3_beamline_library/science/optical_and_loop_centering/loop_edge_detection.py
@@ -129,10 +129,16 @@ class LoopEdgeDetection:
         )
         return loop_extremes
 
-    def fit_rectangle(self) -> RectangleCoordinates:
+    def fit_rectangle(self, height_scale_factor: float = 1) -> RectangleCoordinates:
         """
         Finds the top_left and bottom right coordinates of a rectangle based on the
         find_extremes method
+
+        Parameters
+        ----------
+        height_scale_factor: float
+            When a rectangle is fitted, the heigh of the grid can optically be scaled
+            by `height_scale_factor`
 
         Returns
         -------
@@ -142,9 +148,12 @@ class LoopEdgeDetection:
         """
         extremes = self.find_extremes()
 
+        height = abs(extremes.bottom[1] - extremes.top[1]) / height_scale_factor
+        bottom_coordinate = round(extremes.top[1] + height)
+
         rectangle_coordinates = RectangleCoordinates(
             top_left=np.array([extremes.left[0], extremes.top[1]]),
-            bottom_right=np.array([extremes.right[0], extremes.bottom[1]]),
+            bottom_right=np.array([extremes.right[0], bottom_coordinate]),
         )
 
         return rectangle_coordinates


### PR DESCRIPTION
* Adds a `height_scale_factor` to reduce the height of the grid used to run UDC grid scans
* When running dataset collections via mxcube, we now save the current position so that the current position is not changed when the phase of the MD3 is changed
* Updates `pre-commit`