### PR TITLE
Fix mxcube grid scan

### DIFF
--- a/mx3_beamline_library/plans/manual_xray_centering.py
+++ b/mx3_beamline_library/plans/manual_xray_centering.py
@@ -134,6 +134,8 @@ class ManualXRayCentering(XRayCentering):
         Generator[Msg, None, None]
             A bluesky plan tha centers the a sample using optical and X-ray centering
         """
+        md3.save_centring_position()
+
         if md3.phase.get() != "DataCollection":
             yield from mv(md3.phase, "DataCollection")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mx3-beamline-library"
-version = "1.4.0"
+version = "1.4.1"
 description = "Ophyd devices and bluesky plans."
 authors = ["Stephen Mudie <stephenm@ansto.gov.au>"]
 


### PR DESCRIPTION
Save the md3 centring position before starting an mxcube grid scan