### PR TITLE
Generalise mxcube grid scan

### DIFF
--- a/mx3_beamline_library/devices/classes/md3_config.yml
+++ b/mx3_beamline_library/devices/classes/md3_config.yml
@@ -4,6 +4,6 @@ pixels_per_mm:
   level_2: 622.790
   level_3: 797.109
   level_4: 1040.905
-  level_5: 5904.201
+  level_5: 4229.726
   level_6: 5503.597
   level_7: 8502.362

--- a/mx3_beamline_library/plans/manual_xray_centering.py
+++ b/mx3_beamline_library/plans/manual_xray_centering.py
@@ -231,31 +231,27 @@ class ManualXRayCentering(XRayCentering):
         height_mm = height_pixels / self.zoom.pixels_per_mm
 
         # Y pixel coordinates
-        initial_pos_y_pixels = abs(
-            rectangle_coordinates.top_left[1] - self.beam_position[1]
-        )
-        final_pos_y_pixels = abs(
+        initial_pos_y_pixels = rectangle_coordinates.top_left[1] - self.beam_position[1]
+        final_pos_y_pixels = (
             rectangle_coordinates.bottom_right[1] - self.beam_position[1]
         )
 
         # Alignment y target positions (mm)
         initial_pos_alignment_y = (
-            md3.alignment_y.position - initial_pos_y_pixels / self.zoom.pixels_per_mm
+            md3.alignment_y.position + initial_pos_y_pixels / self.zoom.pixels_per_mm
         )
         final_pos_alignment_y = (
             md3.alignment_y.position + final_pos_y_pixels / self.zoom.pixels_per_mm
         )
 
         # X pixel coordinates
-        initial_pos_x_pixels = abs(
-            rectangle_coordinates.top_left[0] - self.beam_position[0]
-        )
-        final_pos_x_pixels = abs(
+        initial_pos_x_pixels = rectangle_coordinates.top_left[0] - self.beam_position[0]
+        final_pos_x_pixels = (
             rectangle_coordinates.bottom_right[0] - self.beam_position[0]
         )
 
         # Sample x target positions (mm)
-        initial_pos_sample_x = md3.sample_x.position - np.sin(
+        initial_pos_sample_x = md3.sample_x.position + np.sin(
             np.radians(md3.omega.position)
         ) * (initial_pos_x_pixels / self.zoom.pixels_per_mm)
         final_pos_sample_x = md3.sample_x.position + np.sin(
@@ -263,7 +259,7 @@ class ManualXRayCentering(XRayCentering):
         ) * (+final_pos_x_pixels / self.zoom.pixels_per_mm)
 
         # Sample y target positions (mm)
-        initial_pos_sample_y = md3.sample_y.position - np.cos(
+        initial_pos_sample_y = md3.sample_y.position + np.cos(
             np.radians(md3.omega.position)
         ) * (initial_pos_x_pixels / self.zoom.pixels_per_mm)
         final_pos_sample_y = md3.sample_y.position + np.cos(

--- a/mx3_beamline_library/plans/optical_centering.py
+++ b/mx3_beamline_library/plans/optical_centering.py
@@ -1065,31 +1065,27 @@ class OpticalCentering:
         height_mm = height_pixels / md3.zoom.pixels_per_mm
 
         # Y pixel coordinates
-        initial_pos_y_pixels = abs(
-            rectangle_coordinates.top_left[1] - self.beam_position[1]
-        )
-        final_pos_y_pixels = abs(
+        initial_pos_y_pixels = rectangle_coordinates.top_left[1] - self.beam_position[1]
+        final_pos_y_pixels = (
             rectangle_coordinates.bottom_right[1] - self.beam_position[1]
         )
 
         # Alignment y target positions (mm)
         initial_pos_alignment_y = (
-            md3.alignment_y.position - initial_pos_y_pixels / md3.zoom.pixels_per_mm
+            md3.alignment_y.position + initial_pos_y_pixels / md3.zoom.pixels_per_mm
         )
         final_pos_alignment_y = (
             md3.alignment_y.position + final_pos_y_pixels / md3.zoom.pixels_per_mm
         )
 
         # X pixel coordinates
-        initial_pos_x_pixels = abs(
-            rectangle_coordinates.top_left[0] - self.beam_position[0]
-        )
-        final_pos_x_pixels = abs(
+        initial_pos_x_pixels = rectangle_coordinates.top_left[0] - self.beam_position[0]
+        final_pos_x_pixels = (
             rectangle_coordinates.bottom_right[0] - self.beam_position[0]
         )
 
         # Sample x target positions (mm)
-        initial_pos_sample_x = md3.sample_x.position - np.sin(
+        initial_pos_sample_x = md3.sample_x.position + np.sin(
             np.radians(md3.omega.position)
         ) * (initial_pos_x_pixels / md3.zoom.pixels_per_mm)
         final_pos_sample_x = md3.sample_x.position + np.sin(
@@ -1097,7 +1093,7 @@ class OpticalCentering:
         ) * (+final_pos_x_pixels / md3.zoom.pixels_per_mm)
 
         # Sample y target positions (mm)
-        initial_pos_sample_y = md3.sample_y.position - np.cos(
+        initial_pos_sample_y = md3.sample_y.position + np.cos(
             np.radians(md3.omega.position)
         ) * (initial_pos_x_pixels / md3.zoom.pixels_per_mm)
         final_pos_sample_y = md3.sample_y.position + np.cos(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mx3-beamline-library"
-version = "1.4.1"
+version = "1.4.2"
 description = "Ophyd devices and bluesky plans."
 authors = ["Stephen Mudie <stephenm@ansto.gov.au>"]
 


### PR DESCRIPTION
* Grid scans now work independently of the beam initial position
* Fix `pixels_per_mm` value at zoom level 5