### PR TITLE
Get beam center from redis

### DIFF
--- a/examples/mxcube_raster_scan.py
+++ b/examples/mxcube_raster_scan.py
@@ -14,6 +14,7 @@ This example runs a grid scan on a sample based on parameters obtained from mxcu
 import time
 from os import environ
 
+import redis
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 
@@ -33,16 +34,37 @@ RE = RunEngine({})
 bec = BestEffortCallback()
 RE.subscribe(bec)
 
+# Mock beam center, assumes beam_center = a + b * distance + c * distance^2
+redis_client = redis.StrictRedis()
+redis_client.hset(
+    name="beam_center_x_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+redis_client.hset(
+    name="beam_center_y_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+
+
 t = time.perf_counter()
+
 xray_centering = ManualXRayCentering(
-    sample_id="my_sample",
+    sample_id=4,
     grid_scan_id="manual_collection",
-    grid_top_left_coordinate=(388, 502),
-    grid_height=260,
-    grid_width=364,
+    grid_top_left_coordinate=(481, 99),
+    grid_height=78,
+    grid_width=104,
     beam_position=(612, 512),
-    number_of_columns=7,
-    number_of_rows=5,
+    number_of_columns=4,
+    number_of_rows=3,
     detector_distance=0.496,  # m
     photon_energy=13,  # keV
     transmission=0.1,
@@ -51,6 +73,8 @@ xray_centering = ManualXRayCentering(
     count_time=None,
     hardware_trigger=True,
 )
+
+
 RE(xray_centering.start_grid_scan())
 
 print(f"Execution time: {time.perf_counter() - t}")

--- a/examples/optical_centering.py
+++ b/examples/optical_centering.py
@@ -40,14 +40,16 @@ RE.subscribe(bec)
 
 t = time.perf_counter()
 optical_centering = OpticalCentering(
-    sample_id="my_sample",
+    sample_id=1,
     beam_position=(612, 512),
     grid_step=(100, 100),
     plot=True,
-    calibrated_alignment_z=0.45,
+    calibrated_alignment_z=0.47,
     manual_mode=False,
     use_top_camera_camera=True,
-    extra_config=OpticalCenteringExtraConfig(top_camera=TopCamera(x_pixel_target=867)),
+    extra_config=OpticalCenteringExtraConfig(
+        top_camera=TopCamera(x_pixel_target=891.0, y_pixel_target=460.0)
+    ),
 )
 RE(optical_centering.center_loop())
 

--- a/examples/tray_grid_scans.py
+++ b/examples/tray_grid_scans.py
@@ -14,6 +14,7 @@ namely ["A1-1", "A2-1", "B1-1", "B2-1"]
 
 from os import environ
 
+import redis
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 
@@ -34,6 +35,24 @@ RE = RunEngine({})
 bec = BestEffortCallback()
 RE.subscribe(bec)
 
+# Mock beam center, assumes beam_center = a + b * distance + c * distance^2
+redis_client = redis.StrictRedis()
+redis_client.hset(
+    name="beam_center_x_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+redis_client.hset(
+    name="beam_center_y_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
 
 RE(
     multiple_drop_grid_scan(

--- a/examples/x_ray_centering.py
+++ b/examples/x_ray_centering.py
@@ -11,11 +11,14 @@ Before running this example, make sure to run the optical_centering plan first.
     - Access to the MD3 exporter server. If the environment variable
     BL_ACTIVE=False, access to the server is not needed and ophyd
     simulated motors as used as a replacement.
+    - A connection to redis server, which is used to store the
+    beam center
 """
 
 import time
 from os import environ
 
+import redis
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 
@@ -35,9 +38,29 @@ RE = RunEngine({})
 bec = BestEffortCallback()
 RE.subscribe(bec)
 
+# Mock beam center, assumes beam_center = a + b * distance + c * distance^2
+redis_client = redis.StrictRedis()
+redis_client.hset(
+    name="beam_center_x_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+redis_client.hset(
+    name="beam_center_y_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+
+
 t = time.perf_counter()
 xray_centering = XRayCentering(
-    sample_id="my_sample",
+    sample_id=1,
     grid_scan_id="flat",
     detector_distance=0.496,  # m
     photon_energy=13,  # keV

--- a/mx3_beamline_library/config.py
+++ b/mx3_beamline_library/config.py
@@ -1,4 +1,3 @@
-import ast
 from os import environ, path
 
 import yaml
@@ -19,9 +18,6 @@ REDIS_PORT = int(environ.get("REDIS_PORT", "6379"))
 REDIS_USERNAME = environ.get("REDIS_USERNAME", None)
 REDIS_PASSWORD = environ.get("REDIS_PASSWORD", None)
 REDIS_DB = int(environ.get("REDIS_DB", "0"))
-
-# Beam center
-BEAM_CENTER_16M = ast.literal_eval(environ.get("BEAM_CENTER_16M", "(2030, 2145)"))
 
 # Detector
 SIMPLON_API = environ.get("SIMPLON_API", "http://0.0.0.0:8000")

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -18,7 +18,7 @@ from ..devices.motors import md3
 from ..schemas.crystal_finder import MotorCoordinates
 from ..schemas.detector import DetectorConfiguration, UserData
 from ..schemas.xray_centering import MD3ScanResponse, RasterGridCoordinates
-from .beam_utils import set_beam_center_16M
+from .beam_utils import set_beam_center
 from .crystal_pics import save_screen_or_dataset_crystal_pic_to_redis
 from .plan_stubs import md3_move, set_actual_sample_detector_distance, set_transmission
 
@@ -98,7 +98,7 @@ def _md3_scan(  # noqa
         A bluesky stub plan
     """
     # Make sure we set the beam center while in 16M mode
-    set_beam_center_16M()
+    set_beam_center(detector_distance * 1000)
 
     yield from set_transmission(transmission)
 
@@ -555,8 +555,7 @@ def md3_grid_scan(
     Generator
         A bluesky stub plan
     """
-    # Make sure we set the beam center while in 16M mode
-    set_beam_center_16M()
+    set_beam_center(detector_distance * 1000)
 
     yield from set_transmission(transmission)
 
@@ -717,6 +716,8 @@ def md3_4d_scan(
     Generator
         A bluesky stub plan
     """
+    set_beam_center(detector_distance * 1000)
+
     yield from set_transmission(transmission)
 
     # The fast stage detector measures distance in mm

--- a/mx3_beamline_library/plans/beam_utils.py
+++ b/mx3_beamline_library/plans/beam_utils.py
@@ -2,64 +2,131 @@ from urllib.parse import urljoin
 
 from httpx import Client
 
-from ..config import BEAM_CENTER_16M, SIMPLON_API
+from ..config import SIMPLON_API, redis_connection
 from ..logger import setup_logger
 
 logger = setup_logger()
 
 
-def set_beam_center_16M(
-    simplon_api: str | None = None, beam_center_16M: tuple[float, float] | None = None
-) -> tuple[float, float]:
+def set_beam_center(distance: float) -> tuple[float, float]:
     """
-    Sets the beam center in 16M mode. Note that the simplon api
-    rescales the beam center when switching between 16M and 4M modes
-    automatically, so we ensure that we always set the beam center
-    while in 16M mode.
+    Sets the beam center in the simplon api. The beam center is obtained
+    from redis from the keys `beam_center_x_4M` and `beam_center_x_16M`. The
+    coefficients are used to calculate the beam center based on the
+    distance following the formula:
+
+    beam_center = a + b * distance + c * distance^2
+
+    where distance is measured in millimeters. The beam center is then set in
+    the simplon api, where the roi_mode is checked to determine if the
+    beam center should be set for 4M or 16M mode
 
     Parameters
     ----------
-    simplon_api : str | None, optional
-        The simplon api url, by default None. If None, the environment variable
-        is used.
-    beam_center_16M : tuple[float, float] | None, optional
-        The beam center in 16M mode, by default None. If None,
-        the environment variable is used.
+    distance : float
+        The sample detector distance in millimeters
 
     Returns
     -------
     tuple[float, float]
-        The beam center in 16M mode
+        The beam center
     """
-    if simplon_api is None:
-        simplon_api = SIMPLON_API
-
-    if beam_center_16M is None:
-        beam_center_16M = BEAM_CENTER_16M
-
     with Client() as client:
-        # Set beam center in 16M mode
         response = client.get(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode")
+            urljoin(SIMPLON_API, "/detector/api/1.8.0/config/roi_mode")
         )
         response.raise_for_status()
-        if response.json()["value"] != "disabled":
-            response = client.put(
-                urljoin(simplon_api, "/detector/api/1.8.0/config/roi_mode"),
-                json={"value": "disabled"},
-            )
-            response.raise_for_status()
+        if response.json()["value"] == "disabled":
+            beam_center_x, beam_center_y = get_beam_center_16M(distance)
+        elif response.json()["value"] == "4M":
+            beam_center_x, beam_center_y = get_beam_center_4M(distance)
 
         response = client.put(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_x"),
-            json={"value": beam_center_16M[0]},
+            urljoin(SIMPLON_API, "/detector/api/1.8.0/config/beam_center_x"),
+            json={"value": beam_center_x},
         )
         response.raise_for_status()
 
         response = client.put(
-            urljoin(simplon_api, "/detector/api/1.8.0/config/beam_center_y"),
-            json={"value": beam_center_16M[1]},
+            urljoin(SIMPLON_API, "/detector/api/1.8.0/config/beam_center_y"),
+            json={"value": beam_center_y},
         )
         response.raise_for_status()
-    logger.info(f"16M beam center set to {beam_center_16M}")
-    return beam_center_16M
+    logger.info(f"16M beam center set to {(beam_center_x, beam_center_y)}")
+    return beam_center_x, beam_center_y
+
+
+def get_beam_center_4M(distance: float) -> tuple[float, float]:
+    """
+    Gets the beam center for 4M mode from redis. The beam center is calculated using
+    the coefficients stored in redis for the keys `beam_center_x_4M` and
+    `beam_center_y_4M`. The coefficients are used to calculate the beam center
+    based on the distance following the formula:
+    beam_center = a + b * distance + c * distance^2
+
+    where distance is measured in millimeters.
+
+    Parameters
+    ----------
+    distance : float
+        The distance in millimeters
+
+    Returns
+    -------
+    tuple[float, float]
+        The beam center coordinates (x, y)
+    """
+    coefficients_x = redis_connection.hgetall(name="beam_center_x_4M")
+    if not coefficients_x:
+        raise ValueError("No beam center x coefficients found for 4M mode in Redis.")
+    a = float(coefficients_x[b"a"])
+    b = float(coefficients_x[b"b"])
+    c = float(coefficients_x[b"c"])
+    beam_center_x = a + b * distance + c * distance**2
+
+    coefficients_y = redis_connection.hgetall(name="beam_center_y_4M")
+    if not coefficients_y:
+        raise ValueError("No beam center y coefficients found for 4M mode in Redis.")
+    a = float(coefficients_y[b"a"])
+    b = float(coefficients_y[b"b"])
+    c = float(coefficients_y[b"c"])
+    beam_center_y = a + b * distance + c * distance**2
+    return beam_center_x, beam_center_y
+
+
+def get_beam_center_16M(distance: float) -> tuple[float, float]:
+    """
+    Gets the beam center for 16M mode from redis. The beam center is calculated using
+    the coefficients stored in redis for the keys `beam_center_x_16M` and
+    `beam_center_y_16M`. The coefficients are used to calculate the beam center
+    based on the distance following the formula:
+    beam_center = a + b * distance + c * distance^2
+
+    where distance is measured in millimeters.
+
+    Parameters
+    ----------
+    distance : float
+        The distance in millimeters
+
+    Returns
+    -------
+    tuple[float, float]
+        The beam center coordinates (x, y)
+    """
+    coefficients_x = redis_connection.hgetall(name="beam_center_x_16M")
+    if not coefficients_x:
+        raise ValueError("No beam center x coefficients found for 16M mode in Redis.")
+    a = float(coefficients_x[b"a"])
+    b = float(coefficients_x[b"b"])
+    c = float(coefficients_x[b"c"])
+    beam_center_x = a + b * distance + c * distance**2
+
+    coefficients_y = redis_connection.hgetall(name="beam_center_y_16M")
+    if not coefficients_y:
+        raise ValueError("No beam center y coefficients found for 16M mode in Redis.")
+    a = float(coefficients_y[b"a"])
+    b = float(coefficients_y[b"b"])
+    c = float(coefficients_y[b"c"])
+    beam_center_y = a + b * distance + c * distance**2
+    return beam_center_x, beam_center_y

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -18,7 +18,7 @@ from ..logger import setup_logger
 from ..schemas.detector import UserData
 from ..schemas.optical_centering import RasterGridCoordinates
 from .basic_scans import md3_grid_scan, slow_grid_scan
-from .beam_utils import set_beam_center_16M
+from .beam_utils import set_beam_center
 from .image_analysis import get_image_from_md3_camera, unblur_image
 from .plan_stubs import md3_move, set_actual_sample_detector_distance, set_transmission
 from .stubs.devices import validate_raster_grid_limits
@@ -88,8 +88,7 @@ def _single_drop_grid_scan(
     Generator[Msg, None, None]
         A bluesky plan
     """
-    # Make sure we set the beam center while in 16M mode
-    set_beam_center_16M()
+    set_beam_center(detector_distance * 1000)
 
     yield from set_transmission(transmission)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mx3-beamline-library"
-version = "1.7.0"
+version = "1.8.0"
 description = "Ophyd devices and bluesky plans."
 authors = [
   {name="Scientific Computing", email="ScientificComputing@ansto.gov.au"}

--- a/tests/test_beam_center.py
+++ b/tests/test_beam_center.py
@@ -1,0 +1,97 @@
+import json
+
+import httpx
+import respx
+from pytest_mock.plugin import MockerFixture
+
+from mx3_beamline_library.plans.beam_utils import (
+    get_beam_center_4M,
+    get_beam_center_16M,
+    set_beam_center,
+)
+
+
+def test_get_beam_center_16M(fake_redis, mocker: MockerFixture):
+    # Setup
+    mocker.patch(
+        "mx3_beamline_library.plans.beam_utils.redis_connection", new=fake_redis
+    )
+    distance = 500.0  # Example distance in mm
+    fake_redis.hset(name="beam_center_x_16M", mapping={"a": 2000.0, "b": 1.0, "c": 2.0})
+    fake_redis.hset(name="beam_center_y_16M", mapping={"a": 2002.0, "b": 3.0, "c": 4.0})
+    # Exercise
+    beam_center_x, beam_center_y = get_beam_center_16M(distance)
+    # Verify
+    assert beam_center_x == 2000.0 + 1.0 * distance + 2.0 * distance**2
+    assert beam_center_y == 2002.0 + 3.0 * distance + 4.0 * distance**2
+
+
+def test_get_beam_center_4M(fake_redis, mocker: MockerFixture):
+    # Setup
+    mocker.patch(
+        "mx3_beamline_library.plans.beam_utils.redis_connection", new=fake_redis
+    )
+    distance = 500.0  # Example distance in mm
+    fake_redis.hset(name="beam_center_x_4M", mapping={"a": 1000.0, "b": 5.0, "c": 6.0})
+    fake_redis.hset(name="beam_center_y_4M", mapping={"a": 1007.0, "b": 8.0, "c": 9.0})
+    # Exercise
+    beam_center_x, beam_center_y = get_beam_center_4M(distance)
+    # Verify
+    assert beam_center_x == 1000.0 + 5.0 * distance + 6.0 * distance**2
+    assert beam_center_y == 1007.0 + 8.0 * distance + 9.0 * distance**2
+
+
+@respx.mock()
+def test_set_beam_center_16M(respx_mock, fake_redis, mocker: MockerFixture):
+    # Setup
+    roi_mode = respx_mock.get("/detector/api/1.8.0/config/roi_mode").mock(
+        return_value=httpx.Response(200, content=json.dumps({"value": "disabled"}))
+    )
+    beam_center_x_put = respx_mock.put("/detector/api/1.8.0/config/beam_center_x").mock(
+        return_value=httpx.Response(200, content=json.dumps({"value": "disabled"}))
+    )
+    beam_center_y_put = respx_mock.put("/detector/api/1.8.0/config/beam_center_y").mock(
+        return_value=httpx.Response(200, content=json.dumps({"value": "disabled"}))
+    )
+    mocker.patch(
+        "mx3_beamline_library.plans.beam_utils.redis_connection", new=fake_redis
+    )
+    distance = 500.0  # Example distance in mm
+    fake_redis.hset(name="beam_center_x_16M", mapping={"a": 2000.0, "b": 1.0, "c": 2.0})
+    fake_redis.hset(name="beam_center_y_16M", mapping={"a": 2002.0, "b": 3.0, "c": 4.0})
+    # Exercise
+    beam_center_x, beam_center_y = set_beam_center(distance)
+    # Verify
+    assert beam_center_x == 2000.0 + 1.0 * distance + 2.0 * distance**2
+    assert beam_center_y == 2002.0 + 3.0 * distance + 4.0 * distance**2
+    roi_mode.call_count == 1
+    beam_center_x_put.call_count == 1
+    beam_center_y_put.call_count == 1
+
+
+@respx.mock()
+def test_set_beam_center_4M(respx_mock, fake_redis, mocker: MockerFixture):
+    # Setup
+    roi_mode = respx_mock.get("/detector/api/1.8.0/config/roi_mode").mock(
+        return_value=httpx.Response(200, content=json.dumps({"value": "4M"}))
+    )
+    beam_center_x_put = respx_mock.put("/detector/api/1.8.0/config/beam_center_x").mock(
+        return_value=httpx.Response(200, content=json.dumps({}))
+    )
+    beam_center_y_put = respx_mock.put("/detector/api/1.8.0/config/beam_center_y").mock(
+        return_value=httpx.Response(200, content=json.dumps({}))
+    )
+    mocker.patch(
+        "mx3_beamline_library.plans.beam_utils.redis_connection", new=fake_redis
+    )
+    distance = 500.0  # Example distance in mm
+    fake_redis.hset(name="beam_center_x_4M", mapping={"a": 1000.0, "b": 5.0, "c": 6.0})
+    fake_redis.hset(name="beam_center_y_4M", mapping={"a": 1007.0, "b": 8.0, "c": 9.0})
+    # Exercise
+    beam_center_x, beam_center_y = set_beam_center(distance)
+    # Verify
+    assert beam_center_x == 1000.0 + 5.0 * distance + 6.0 * distance**2
+    assert beam_center_y == 1007.0 + 8.0 * distance + 9.0 * distance**2
+    roi_mode.call_count == 1
+    beam_center_x_put.call_count == 1
+    beam_center_y_put.call_count == 1

--- a/tests/test_tray_scans.py
+++ b/tests/test_tray_scans.py
@@ -42,9 +42,7 @@ def test_single_drop_grid_scan(
     det_distance = mocker.patch(
         "mx3_beamline_library.plans.tray_scans.set_actual_sample_detector_distance"
     )
-    beam_center = mocker.patch(
-        "mx3_beamline_library.plans.tray_scans.set_beam_center_16M"
-    )
+    beam_center = mocker.patch("mx3_beamline_library.plans.tray_scans.set_beam_center")
 
     drop_location = "A2-1"
 
@@ -90,9 +88,7 @@ def test_multiple_drop_grid_scan(
     det_distance = mocker.patch(
         "mx3_beamline_library.plans.tray_scans.set_actual_sample_detector_distance"
     )
-    beam_center = mocker.patch(
-        "mx3_beamline_library.plans.tray_scans.set_beam_center_16M"
-    )
+    beam_center = mocker.patch("mx3_beamline_library.plans.tray_scans.set_beam_center")
 
     drop_locations = ["A2-1", "A1-1"]
 
@@ -139,9 +135,7 @@ def test_multiple_drop_grid_scan_frame_rate_error(
     mocker.patch(
         "mx3_beamline_library.plans.tray_scans.redis_connection", new=fake_redis
     )
-    beam_center = mocker.patch(
-        "mx3_beamline_library.plans.tray_scans.set_beam_center_16M"
-    )
+    beam_center = mocker.patch("mx3_beamline_library.plans.tray_scans.set_beam_center")
     drop_locations = ["A2-1", "A1-1"]
     md3_alignment_y_speed = 18  # This triggers the frame rate error
 
@@ -177,9 +171,7 @@ def test_multiple_drop_grid_scan_width_error(
     mocker.patch(
         "mx3_beamline_library.plans.tray_scans.redis_connection", new=fake_redis
     )
-    beam_center = mocker.patch(
-        "mx3_beamline_library.plans.tray_scans.set_beam_center_16M"
-    )
+    beam_center = mocker.patch("mx3_beamline_library.plans.tray_scans.set_beam_center")
     drop_locations = ["A2-1", "A1-1"]
     grid_number_of_columns = 1  # This triggers the width error
 

--- a/uv.lock
+++ b/uv.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "mx3-beamline-library"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "bitshuffle" },


### PR DESCRIPTION
* Gets the beam center from redis.  The beam center is calculated using the coefficients stored in redis for the keys `beam_center_x_16M`, `beam_center_y_16M` , and `beam_center_x_4M`, `beam_center_y_4M` . The coefficients are used to calculate the beam center based on the distance following the formula:
 
```beam_center = a + b * distance + c * distance^2```
    
where distance is measured in millimeters.