### PR TITLE
One shot

### DIFF
--- a/examples/one_shot.py
+++ b/examples/one_shot.py
@@ -1,0 +1,70 @@
+"""
+This example runs a screening plan
+
+    Requirements:
+    - Access to the Dectris SIMPLON API (or Simulated SIMPLON-API)
+    - Access to the MD3 exporter server. If the environment variable
+        BL_ACTIVE=False, access to the server is not needed and ophyd
+        simulated motors as used as a replacement.
+    - A connection to a Redis server, which is used to store the
+    beam center
+"""
+
+import time
+from os import environ
+
+import redis
+from bluesky import RunEngine
+from bluesky.callbacks.best_effort import BestEffortCallback
+
+# Modify the following ENV variables with the corresponding
+# hosts and ports.
+# IF BL_ACTIVE=False, we run the library in simulation mode
+environ["BL_ACTIVE"] = "False"
+environ["SIMPLON_API"] = "http://0.0.0.0:8000"
+environ["MD3_REDIS_HOST"] = "12.345.678.90"
+environ["MD3_REDIS_PORT"] = "6379"
+environ["MD3_ADDRESS"] = "12.345.678.90"
+environ["MD3_PORT"] = "9001"
+from mx3_beamline_library.plans.basic_scans import md3_scan  # noqa
+
+# Instantiate run engine an start plan
+RE = RunEngine({})
+bec = BestEffortCallback()
+RE.subscribe(bec)
+
+# Mock beam center, assumes beam_center = a + b * distance + c * distance^2
+redis_client = redis.StrictRedis()
+redis_client.hset(
+    name="beam_center_x_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+redis_client.hset(
+    name="beam_center_y_16M",
+    mapping={
+        "a": 2000.0,
+        "b": 0.0,
+        "c": 0.0,
+    },
+)
+
+# Run plan
+t = time.perf_counter()
+one_shot = md3_scan(
+    id=1,
+    scan_range=20,
+    exposure_time=2,
+    number_of_frames=1,
+    detector_distance=0.4,
+    photon_energy=13,
+    transmission=0.1,
+    collection_type="one_shot",
+)
+
+RE(one_shot)
+
+print(f"Execution time: {time.perf_counter() - t}")

--- a/examples/one_shot.py
+++ b/examples/one_shot.py
@@ -56,8 +56,8 @@ redis_client.hset(
 t = time.perf_counter()
 one_shot = md3_scan(
     id=1,
-    scan_range=20,
-    exposure_time=2,
+    scan_range=1,
+    exposure_time=1,
     number_of_frames=1,
     detector_distance=0.4,
     photon_energy=13,

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -47,7 +47,7 @@ def _md3_scan(  # noqa
     hardware_trigger: bool = True,
     crystal_id: int = 0,
     data_collection_id: int = 0,
-    collection_type: Literal["screening", "dataset"] = "dataset",
+    collection_type: Literal["screening", "dataset", "one_shot"] = "dataset",
 ) -> Generator[Msg, None, None]:
     """
     Runs an MD3 scan on a crystal.
@@ -198,9 +198,9 @@ def _md3_scan(  # noqa
     user_data = UserData(
         id=id,
         drop_location=drop_location,
-        zmq_consumer_mode="filewriter",
         crystal_id=crystal_id,
         data_collection_id=data_collection_id,
+        collection_type=collection_type,
     )
 
     detector_configuration = DetectorConfiguration(
@@ -322,7 +322,7 @@ def md3_scan(
     hardware_trigger: bool = True,
     crystal_id: int = 0,
     data_collection_id: int = 0,
-    collection_type: Literal["screening", "dataset"] = "dataset",
+    collection_type: Literal["screening", "dataset", "one_shot"] = "dataset",
 ) -> Generator[Msg, None, None]:
     """
     Runs an MD3 scan on a crystal. If tray_scan=True, the start angle of the scan is either

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -223,13 +223,14 @@ def _md3_scan(  # noqa
 
     yield from stage(dectris_detector)
 
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id=id,
-        crystal_counter=crystal_id,
-        data_collection_counter=data_collection_id,
-        type=collection_type,
-        collection_stage="start",
-    )
+    if collection_type in ["dataset", "screening"]:
+        save_screen_or_dataset_crystal_pic_to_redis(
+            sample_id=id,
+            crystal_counter=crystal_id,
+            data_collection_counter=data_collection_id,
+            type=collection_type,
+            collection_stage="start",
+        )
     if BL_ACTIVE == "true":
         if hardware_trigger:
             scan_idx = 1  # NOTE: This does not seem to serve any useful purpose
@@ -283,13 +284,14 @@ def _md3_scan(  # noqa
             f"Scan did not run successfully: {scan_response.model_dump()}"
         )
 
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id=id,
-        crystal_counter=crystal_id,
-        data_collection_counter=data_collection_id,
-        type=collection_type,
-        collection_stage="end",
-    )
+    if collection_type in ["dataset", "screening"]:
+        save_screen_or_dataset_crystal_pic_to_redis(
+            sample_id=id,
+            crystal_counter=crystal_id,
+            data_collection_counter=data_collection_id,
+            type=collection_type,
+            collection_stage="end",
+        )
     if tray_scan:
         # Move tray back to either 91 or 270 degrees depending on the tray type
         omega_position = md3.omega.position

--- a/mx3_beamline_library/plans/tray_scans.py
+++ b/mx3_beamline_library/plans/tray_scans.py
@@ -97,10 +97,10 @@ def _single_drop_grid_scan(
 
     user_data = UserData(
         id=tray_id,
-        zmq_consumer_mode="spotfinder",
         number_of_columns=grid_number_of_columns,
         number_of_rows=grid_number_of_rows,
         grid_scan_id=drop_location,
+        collection_type="grid_scan",
     )
     if md3_alignment_y_speed > 14.8:
         raise ValueError(

--- a/mx3_beamline_library/plans/xray_centering.py
+++ b/mx3_beamline_library/plans/xray_centering.py
@@ -228,10 +228,10 @@ class XRayCentering:
         # and keeping the values of sample_x, sample_y, and alignment_z constant
         user_data = UserData(
             id=self.sample_id,
-            zmq_consumer_mode="spotfinder",
             grid_scan_id=self.grid_scan_id,
             number_of_columns=grid.number_of_columns,
             number_of_rows=grid.number_of_rows,
+            collection_type="grid_scan",
         )
         if isinstance(self.grid_scan_id, str):
             if self.grid_scan_id.lower() == "flat":

--- a/mx3_beamline_library/schemas/detector.py
+++ b/mx3_beamline_library/schemas/detector.py
@@ -7,9 +7,6 @@ class UserData(BaseModel):
     """Data passed to the detector ZMQ-stream"""
 
     id: str | int = Field(description="ID of the sample or tray")
-    zmq_consumer_mode: Literal["spotfinder", "filewriter"] = Field(
-        default="spotfinder", description="Could be either filewriter or spotfinder"
-    )
     number_of_columns: int | None = Field(
         None, description="number of columns of the grid scan"
     )
@@ -27,6 +24,7 @@ class UserData(BaseModel):
         None,
         description="The location of the drop used to identify screening datasets",
     )
+    collection_type: Literal["screening", "dataset", "one_shot", "grid_scan"]
     model_config = ConfigDict(extra="forbid")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mx3-beamline-library"
-version = "1.8.4"
+version = "1.9.0"
 description = "Ophyd devices and bluesky plans."
 authors = [
   {name="Scientific Computing", email="ScientificComputing@ansto.gov.au"}

--- a/tests/test_basic_scans.py
+++ b/tests/test_basic_scans.py
@@ -123,7 +123,7 @@ def test_md3_grid_scan(respx_mock, run_engine, mocker: MockerFixture):
 
     user_data = UserData(
         id="my_sample",
-        zmq_consumer_mode="spotfinder",
+        collection_type="grid_scan",
         grid_scan_id="flat",
     )
 
@@ -181,7 +181,7 @@ def test_md3_4d_scan(respx_mock, run_engine, mocker: MockerFixture):
     )
     user_data = UserData(
         id="my_sample",
-        zmq_consumer_mode="spotfinder",
+        collection_type="grid_scan",
         grid_scan_id="flat",
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "mx3-beamline-library"
-version = "1.8.4"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "bitshuffle" },


### PR DESCRIPTION
* Adds support for running `one-shot` scans
* Removes the `zmq_consumer_mode` key from the user data in favour of `collection_type`