### PR TITLE
Detector only moves when needed, transmission set every mount

### DIFF
--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -5,12 +5,11 @@ from bluesky.plan_stubs import close_run, mv, open_run
 from bluesky.utils import Msg
 from mx_robot_library.schemas.common.sample import Pin
 
-from ..devices.motors import isara_robot, md3, actual_sample_detector_distance
+from ..devices.motors import actual_sample_detector_distance, isara_robot, md3
 from .plan_stubs import (
-    set_distance_phase_and_transmission,
     set_distance_and_transmission,
+    set_distance_phase_and_transmission,
 )
-
 
 # TODO: Move constants to env or get from redis?
 SAFE_MOUNT_DISTANCE: float = 380  # mm

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -5,8 +5,15 @@ from bluesky.plan_stubs import close_run, mv, open_run
 from bluesky.utils import Msg
 from mx_robot_library.schemas.common.sample import Pin
 
-from ..devices.motors import isara_robot, md3
-from .plan_stubs import set_actual_sample_detector_distance, set_distance_and_md3_phase
+from ..devices.motors import isara_robot, md3, actual_sample_detector_distance
+from .plan_stubs import (
+    set_actual_sample_detector_distance,
+    set_distance_phase_and_transmission,
+)
+
+# TODO: Move constants to env or get from redis?
+SAFE_MOUNT_DISTANCE: float = 380  # mm
+BEAMSTEERING_TRANSMISSION: float = 0.05  # 5%
 
 
 def mount_pin(
@@ -29,10 +36,16 @@ def mount_pin(
         A bluesky plan
     """
     yield from open_run()
-    sample_detector_distance = 380  # mm
+    sample_detector_distance = actual_sample_detector_distance.get()
+    if sample_detector_distance < SAFE_MOUNT_DISTANCE:
+        sample_detector_distance = SAFE_MOUNT_DISTANCE
 
     if md3.phase.get() != "Transfer":
-        yield from set_distance_and_md3_phase(sample_detector_distance, "Transfer")
+        yield from set_distance_phase_and_transmission(
+            sample_detector_distance,
+            "Transfer",
+            BEAMSTEERING_TRANSMISSION,
+        )
     else:
         yield from set_actual_sample_detector_distance(sample_detector_distance)
 
@@ -51,10 +64,16 @@ def unmount_pin() -> Generator[Msg, None, None]:
         A bluesky stub plan
     """
     yield from open_run()
-    sample_detector_distance = 380  # mm
+    sample_detector_distance = actual_sample_detector_distance.get()
+    if sample_detector_distance < SAFE_MOUNT_DISTANCE:
+        sample_detector_distance = SAFE_MOUNT_DISTANCE
 
     if md3.phase.get() != "Transfer":
-        yield from set_distance_and_md3_phase(sample_detector_distance, "Transfer")
+        yield from set_distance_phase_and_transmission(
+            sample_detector_distance,
+            "Transfer",
+            BEAMSTEERING_TRANSMISSION,
+        )
     else:
         yield from set_actual_sample_detector_distance(sample_detector_distance)
 
@@ -77,10 +96,16 @@ def mount_tray(id: int) -> Generator[Msg, None, None]:
     Generator[Msg, None, None]
         A bluesky plan
     """
-    sample_detector_distance = 380  # mm
+    sample_detector_distance = actual_sample_detector_distance.get()
+    if sample_detector_distance < SAFE_MOUNT_DISTANCE:
+        sample_detector_distance = SAFE_MOUNT_DISTANCE
 
     if md3.phase.get() != "Transfer":
-        yield from set_distance_and_md3_phase(sample_detector_distance, "Transfer")
+        yield from set_distance_phase_and_transmission(
+            sample_detector_distance,
+            "Transfer",
+            BEAMSTEERING_TRANSMISSION,
+        )
     else:
         yield from set_actual_sample_detector_distance(sample_detector_distance)
 
@@ -97,11 +122,16 @@ def unmount_tray() -> Generator[Msg, None, None]:
     Generator[Msg, None, None]
         A bluesky plan
     """
-
-    sample_detector_distance = 380  # mm
+    sample_detector_distance = actual_sample_detector_distance.get()
+    if sample_detector_distance < SAFE_MOUNT_DISTANCE:
+        sample_detector_distance = SAFE_MOUNT_DISTANCE
 
     if md3.phase.get() != "Transfer":
-        yield from set_distance_and_md3_phase(sample_detector_distance, "Transfer")
+        yield from set_distance_phase_and_transmission(
+            sample_detector_distance,
+            "Transfer",
+            BEAMSTEERING_TRANSMISSION,
+        )
     else:
         yield from set_actual_sample_detector_distance(sample_detector_distance)
 

--- a/mx3_beamline_library/plans/robot.py
+++ b/mx3_beamline_library/plans/robot.py
@@ -7,9 +7,10 @@ from mx_robot_library.schemas.common.sample import Pin
 
 from ..devices.motors import isara_robot, md3, actual_sample_detector_distance
 from .plan_stubs import (
-    set_actual_sample_detector_distance,
     set_distance_phase_and_transmission,
+    set_distance_and_transmission,
 )
+
 
 # TODO: Move constants to env or get from redis?
 SAFE_MOUNT_DISTANCE: float = 380  # mm
@@ -47,7 +48,10 @@ def mount_pin(
             BEAMSTEERING_TRANSMISSION,
         )
     else:
-        yield from set_actual_sample_detector_distance(sample_detector_distance)
+        yield from set_distance_and_transmission(
+            sample_detector_distance,
+            BEAMSTEERING_TRANSMISSION,
+        )
 
     yield from mv(isara_robot.mount, {"pin": pin, "prepick_pin": prepick_pin})
     yield from mv(md3.phase, "Centring")
@@ -75,7 +79,10 @@ def unmount_pin() -> Generator[Msg, None, None]:
             BEAMSTEERING_TRANSMISSION,
         )
     else:
-        yield from set_actual_sample_detector_distance(sample_detector_distance)
+        yield from set_distance_and_transmission(
+            sample_detector_distance,
+            BEAMSTEERING_TRANSMISSION,
+        )
 
     yield from mv(isara_robot.unmount, None)
     yield from close_run()
@@ -107,7 +114,10 @@ def mount_tray(id: int) -> Generator[Msg, None, None]:
             BEAMSTEERING_TRANSMISSION,
         )
     else:
-        yield from set_actual_sample_detector_distance(sample_detector_distance)
+        yield from set_distance_and_transmission(
+            sample_detector_distance,
+            BEAMSTEERING_TRANSMISSION,
+        )
 
     yield from mv(isara_robot.mount_tray, id)
 
@@ -133,7 +143,10 @@ def unmount_tray() -> Generator[Msg, None, None]:
             BEAMSTEERING_TRANSMISSION,
         )
     else:
-        yield from set_actual_sample_detector_distance(sample_detector_distance)
+        yield from set_distance_and_transmission(
+            sample_detector_distance,
+            BEAMSTEERING_TRANSMISSION,
+        )
 
     yield from mv(isara_robot.unmount_tray, None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "mx3-beamline-library"
-version = "1.9.7"
+version = "1.9.8"
 description = "Ophyd devices and bluesky plans."
 authors = [
-  {name="Scientific Computing", email="ScientificComputing@ansto.gov.au"}
-  ]
+  { name = "Scientific Computing", email = "ScientificComputing@ansto.gov.au" },
+]
 maintainers = [
-  {name="Francisco Hernandez Vivanco", email="hernandf@ansto.gov.au"},
-  {name="Daniel Eriksson", email="daniele@ansto.gov.au"},
-  {name="Kate Smith", email="kates@ansto.gov.au"}
+  { name = "Francisco Hernandez Vivanco", email = "hernandf@ansto.gov.au" },
+  { name = "Daniel Eriksson", email = "daniele@ansto.gov.au" },
+  { name = "Kate Smith", email = "kates@ansto.gov.au" },
 ]
 requires-python = ">=3.11,<3.13"
 dependencies = [
@@ -33,12 +33,12 @@ dependencies = [
   "pandas (>=2.0.2)",
   "tiled (==0.1.0a105)",
   "httpx-file (>=0.2.0)",
-  ]
+]
 
 [project.optional-dependencies]
 as-dependencies = [
-    "as-acquisition-library @ git+https://bitbucket.synchrotron.org.au/scm/ec/as-acquisition-library.git@main",
-    "as-redis-signal  @ git+https://bitbucket.synchrotron.org.au/scm/ec/as-redis-signal.git@main ",
+  "as-acquisition-library @ git+https://bitbucket.synchrotron.org.au/scm/ec/as-acquisition-library.git@main",
+  "as-redis-signal  @ git+https://bitbucket.synchrotron.org.au/scm/ec/as-redis-signal.git@main ",
 ]
 
 


### PR DESCRIPTION
1.  Detector fast stage only moves if inside the robot safe mount envelope. Note that that distance is currently hard-coded but should be read directly from a PV. 
2. Transmission is set to 5% every mount to allow the beam steering script to run; the beam positioning monitors only work inside a specific flux band. This should not affect any data collection as transmission is explicitly set every collection. 
 