### PR TITLE
Improve error messages

### DIFF
--- a/mx3_beamline_library/devices/sim/classes/motors.py
+++ b/mx3_beamline_library/devices/sim/classes/motors.py
@@ -636,16 +636,18 @@ class SimMotorState(Signal):
             plc_last_msg="ERROR 9150 - User acknowledgement required",
         )
 
+
 class MountSignalSim(Signal):
 
     def _set_and_wait(self, value, timeout, **kwargs):
-        super()._set_and_wait(value, timeout, **kwargs)
         from mx_robot_library.exceptions.base import PLCError
 
         try:
             raise PLCError("This is a test")
         except Exception as exc:
             self._status.set_exception(exc)
+
+
 class IsaraRobot(Device):
     # TODO: Properly implement this sim device. This is a quick fix for the
     # queueserver in sim mode

--- a/mx3_beamline_library/devices/sim/classes/motors.py
+++ b/mx3_beamline_library/devices/sim/classes/motors.py
@@ -637,20 +637,9 @@ class SimMotorState(Signal):
         )
 
 
-class MountSignalSim(Signal):
-
-    def _set_and_wait(self, value, timeout, **kwargs):
-        from mx_robot_library.exceptions.base import PLCError
-
-        try:
-            raise PLCError("This is a test")
-        except Exception as exc:
-            self._status.set_exception(exc)
-
-
 class IsaraRobot(Device):
-    # TODO: Properly implement this sim device. This is a quick fix for the
-    # queueserver in sim mode
-    mount = Cpt(MountSignalSim, name="mount")
+    mount = Cpt(Signal, name="mount")
     unmount = Cpt(Signal, name="unmount")
-    state = Cpt(SimMotorState, name="state")
+    state = Cpt(Signal, name="state")
+    mount_tray = Cpt(Signal, name="mount_tray")
+    unmount_tray = Cpt(Signal, name="unmount_tray")

--- a/mx3_beamline_library/devices/sim/classes/motors.py
+++ b/mx3_beamline_library/devices/sim/classes/motors.py
@@ -636,10 +636,19 @@ class SimMotorState(Signal):
             plc_last_msg="ERROR 9150 - User acknowledgement required",
         )
 
+class MountSignalSim(Signal):
 
+    def _set_and_wait(self, value, timeout, **kwargs):
+        super()._set_and_wait(value, timeout, **kwargs)
+        from mx_robot_library.exceptions.base import PLCError
+
+        try:
+            raise PLCError("This is a test")
+        except Exception as exc:
+            self._status.set_exception(exc)
 class IsaraRobot(Device):
     # TODO: Properly implement this sim device. This is a quick fix for the
     # queueserver in sim mode
-    mount = Cpt(MX3SimMotor, name="mount")
-    unmount = Cpt(MX3SimMotor, name="unmount")
+    mount = Cpt(MountSignalSim, name="mount")
+    unmount = Cpt(Signal, name="unmount")
     state = Cpt(SimMotorState, name="state")

--- a/mx3_beamline_library/plans/basic_scans.py
+++ b/mx3_beamline_library/plans/basic_scans.py
@@ -789,6 +789,13 @@ def md3_4d_scan(
 def _calculate_alignment_z_motor_coords(
     raster_grid_coords: RasterGridCoordinates,
 ) -> npt.NDArray:
+    # TODO: handle the case when number_of_columns == 1 when using the
+    # alignment table. For now, we raise an error
+    if raster_grid_coords.number_of_columns == 1:
+        raise NotImplementedError(
+            "Grid scans with number_of_columns == 1 are not supported "
+            "when using the alignment table"
+        )
 
     delta = abs(
         raster_grid_coords.initial_pos_alignment_z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mx3-beamline-library"
-version = "1.9.8"
+version = "1.9.9"
 description = "Ophyd devices and bluesky plans."
 authors = [
   { name = "Scientific Computing", email = "ScientificComputing@ansto.gov.au" },

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "mx3-beamline-library"
-version = "1.9.7"
+version = "1.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitshuffle" },


### PR DESCRIPTION
* When an exception occurs inside a signal (e.g. `mount` or `unmount`), it's now properly stored in the signal's status. This means that the error can be propagated and displayed in Prefect and mxcube
* Updates the sim robot ophyd device