### PR TITLE
UUID

### DIFF
--- a/examples/mxcube_raster_scan.py
+++ b/examples/mxcube_raster_scan.py
@@ -13,6 +13,7 @@ This example runs a grid scan on a sample based on parameters obtained from mxcu
 
 import time
 from os import environ
+from uuid import uuid4
 
 import redis
 from bluesky import RunEngine
@@ -57,8 +58,7 @@ redis_client.hset(
 t = time.perf_counter()
 
 xray_centering = ManualXRayCentering(
-    sample_id=4,
-    data_collection_id=0,
+    acquisition_uuid=uuid4(),
     grid_top_left_coordinate=(481, 99),
     grid_height=78,
     grid_width=104,

--- a/examples/one_shot.py
+++ b/examples/one_shot.py
@@ -12,6 +12,7 @@ This example runs a screening plan
 
 import time
 from os import environ
+from uuid import uuid4
 
 import redis
 from bluesky import RunEngine
@@ -55,7 +56,7 @@ redis_client.hset(
 # Run plan
 t = time.perf_counter()
 one_shot = md3_scan(
-    id=1,
+    acquisition_uuid=uuid4(),
     scan_range=1,
     exposure_time=1,
     number_of_frames=1,

--- a/examples/optical_centering.py
+++ b/examples/optical_centering.py
@@ -16,6 +16,7 @@ The results are saved to redis
 import time
 from os import environ
 
+import redis
 from bluesky import RunEngine
 from bluesky.callbacks.best_effort import BestEffortCallback
 
@@ -31,6 +32,22 @@ from mx3_beamline_library.plans.optical_centering import OpticalCentering  # noq
 from mx3_beamline_library.schemas.optical_centering import (  # noqa
     OpticalCenteringExtraConfig,
     TopCamera,
+)
+
+redis_connection = redis.StrictRedis()
+redis_connection.hset(
+    "top_camera_target_coords",
+    mapping={
+        "x_pixel_target": 400,
+        "y_pixel_target": 400,
+    },
+)
+redis_connection.hset(
+    "top_camera_pixels_per_mm",
+    mapping={
+        "pixels_per_mm_x": 40,
+        "pixels_per_mm_y": 40,
+    },
 )
 
 # Instantiate run engine and start plan

--- a/examples/screening.py
+++ b/examples/screening.py
@@ -12,6 +12,7 @@ This example runs a screening plan
 
 import time
 from os import environ
+from uuid import uuid4
 
 import redis
 from bluesky import RunEngine
@@ -55,7 +56,7 @@ redis_client.hset(
 # Run plan
 t = time.perf_counter()
 screening = md3_scan(
-    id=1,
+    acquisition_uuid=uuid4(),
     scan_range=20,
     exposure_time=2,
     number_of_frames=1,

--- a/examples/x_ray_centering.py
+++ b/examples/x_ray_centering.py
@@ -17,6 +17,7 @@ Before running this example, make sure to run the optical_centering plan first.
 
 import time
 from os import environ
+from uuid import uuid4
 
 import redis
 from bluesky import RunEngine
@@ -61,7 +62,7 @@ redis_client.hset(
 t = time.perf_counter()
 xray_centering = XRayCentering(
     sample_id=1,
-    data_collection_id=0,
+    acquisition_uuid=uuid4(),
     grid_scan_id="flat",
     detector_distance=0.496,  # m
     photon_energy=13,  # keV

--- a/mx3_beamline_library/plans/manual_xray_centering.py
+++ b/mx3_beamline_library/plans/manual_xray_centering.py
@@ -13,6 +13,7 @@ from ..plans.plan_stubs import md3_move
 from ..schemas.crystal_finder import MotorCoordinates
 from ..schemas.loop_edge_detection import RectangleCoordinates
 from ..schemas.xray_centering import RasterGridCoordinates
+from .crystal_pics import save_mxcube_grid_scan_crystal_pic
 from .stubs.devices import validate_raster_grid_limits
 from .xray_centering import XRayCentering
 
@@ -27,9 +28,7 @@ class ManualXRayCentering(XRayCentering):
 
     def __init__(
         self,
-        sample_id: int,
         acquisition_uuid: UUID,
-        data_collection_id: int,
         grid_top_left_coordinate: tuple[int, int] | list[int],
         grid_width: int,
         grid_height: int,
@@ -48,10 +47,8 @@ class ManualXRayCentering(XRayCentering):
         """
         Parameters
         ----------
-        sample_id: str
-            Sample id
-        data_collection_id : int
-            Data collection id
+        acquisition_uuid : UUID
+            The acquisition uuid
         grid_top_left_coordinate : Union[list, tuple[int, int]]
             Top left coordinate of the scan in pixels
         grid_width : int
@@ -88,9 +85,8 @@ class ManualXRayCentering(XRayCentering):
         None
         """
         super().__init__(
-            sample_id=sample_id,
+            sample_id=None,
             acquisition_uuid=acquisition_uuid,
-            data_collection_id=data_collection_id,
             detector_distance=detector_distance,
             photon_energy=photon_energy,
             transmission=transmission,
@@ -149,10 +145,11 @@ class ManualXRayCentering(XRayCentering):
         validate_raster_grid_limits(grid)
 
         redis_connection.set(
-            f"mxcube_raster_grid:sample_id_{self.sample_id}:grid_scan_id_{self.data_collection_id}",  # noqa
+            f"mxcube:raster_grid:{self.acquisition_uuid}",
             pickle.dumps(grid.model_dump()),
             ex=3600,
         )
+        save_mxcube_grid_scan_crystal_pic(self.acquisition_uuid)
 
         logger.info(f"Running grid scan: {self.grid_scan_id}")
 
@@ -188,7 +185,9 @@ class ManualXRayCentering(XRayCentering):
             The plan generator
         """
         yield from monitor_during_wrapper(
-            run_wrapper(self._start_grid_scan(), md={"sample_id": self.sample_id}),
+            run_wrapper(
+                self._start_grid_scan(), md={"acquisition_uuid": self.acquisition_uuid}
+            ),
             signals=(self.md3_scan_response,),
         )
 

--- a/mx3_beamline_library/plans/manual_xray_centering.py
+++ b/mx3_beamline_library/plans/manual_xray_centering.py
@@ -1,5 +1,6 @@
 import pickle
 from typing import Generator
+from uuid import UUID
 
 import numpy as np
 from bluesky.preprocessors import monitor_during_wrapper, run_wrapper
@@ -27,6 +28,7 @@ class ManualXRayCentering(XRayCentering):
     def __init__(
         self,
         sample_id: int,
+        acquisition_uuid: UUID,
         data_collection_id: int,
         grid_top_left_coordinate: tuple[int, int] | list[int],
         grid_width: int,
@@ -87,6 +89,7 @@ class ManualXRayCentering(XRayCentering):
         """
         super().__init__(
             sample_id=sample_id,
+            acquisition_uuid=acquisition_uuid,
             data_collection_id=data_collection_id,
             detector_distance=detector_distance,
             photon_energy=photon_energy,

--- a/mx3_beamline_library/plans/xray_centering.py
+++ b/mx3_beamline_library/plans/xray_centering.py
@@ -30,9 +30,8 @@ class XRayCentering:
 
     def __init__(
         self,
-        sample_id: int,
+        sample_id: int | None,
         acquisition_uuid: UUID,
-        data_collection_id: int,
         detector_distance: float,
         photon_energy: float,
         transmission: float,
@@ -45,12 +44,10 @@ class XRayCentering:
         """
         Parameters
         ----------
-        sample_id: int
-            The database sample id
+        sample_id : int | None
+            The database sample id. Only used for UDC
         acquisition_uuid: UUID
             The UUID of the acquisition
-        data_collection_id: int
-            The data collection id
         detector_distance: float
             The detector distance in meters
         photon_energy: float
@@ -80,7 +77,6 @@ class XRayCentering:
         self.sample_id = sample_id
         self.acquisition_uuid = acquisition_uuid
         self.grid_scan_id = grid_scan_id
-        self.data_collection_id = data_collection_id
         self.md3_alignment_y_speed = md3_alignment_y_speed
         self.omega_range = omega_range
         self.count_time = count_time
@@ -239,9 +235,7 @@ class XRayCentering:
         # number_of_columns < 2 we use the md3_3d_scan instead, setting scan_range=0,
         # and keeping the values of sample_x, sample_y, and alignment_z constant
         user_data = UserData(
-            sample_id=self.sample_id,
             acquisition_uuid=self.acquisition_uuid,
-            data_collection_id=self.data_collection_id,
             number_of_columns=grid.number_of_columns,
             number_of_rows=grid.number_of_rows,
             collection_type="grid_scan",

--- a/mx3_beamline_library/plans/xray_centering.py
+++ b/mx3_beamline_library/plans/xray_centering.py
@@ -1,5 +1,6 @@
 import pickle
 from typing import Generator, Literal
+from uuid import UUID
 
 from bluesky.plan_stubs import mv
 from bluesky.preprocessors import monitor_during_wrapper, run_wrapper
@@ -30,6 +31,7 @@ class XRayCentering:
     def __init__(
         self,
         sample_id: int,
+        acquisition_uuid: UUID,
         data_collection_id: int,
         detector_distance: float,
         photon_energy: float,
@@ -44,7 +46,9 @@ class XRayCentering:
         Parameters
         ----------
         sample_id: int
-            Sample id
+            The database sample id
+        acquisition_uuid: UUID
+            The UUID of the acquisition
         data_collection_id: int
             The data collection id
         detector_distance: float
@@ -74,6 +78,7 @@ class XRayCentering:
         None
         """
         self.sample_id = sample_id
+        self.acquisition_uuid = acquisition_uuid
         self.grid_scan_id = grid_scan_id
         self.data_collection_id = data_collection_id
         self.md3_alignment_y_speed = md3_alignment_y_speed
@@ -235,6 +240,7 @@ class XRayCentering:
         # and keeping the values of sample_x, sample_y, and alignment_z constant
         user_data = UserData(
             sample_id=self.sample_id,
+            acquisition_uuid=self.acquisition_uuid,
             data_collection_id=self.data_collection_id,
             number_of_columns=grid.number_of_columns,
             number_of_rows=grid.number_of_rows,
@@ -331,7 +337,9 @@ class XRayCentering:
             else:
                 detector_configuration = {
                     "nimages": 1,
-                    "user_data": user_data.model_dump(),
+                    "user_data": user_data.model_dump(
+                        mode="json", by_alias=True, exclude_none=True
+                    ),
                     "trigger_mode": "ints",
                     "ntrigger": grid.number_of_columns * grid.number_of_rows,
                 }
@@ -350,7 +358,9 @@ class XRayCentering:
         elif BL_ACTIVE == "false":
             detector_configuration = {
                 "nimages": 1,
-                "user_data": user_data.model_dump(),
+                "user_data": user_data.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                ),
                 "trigger_mode": "ints",
                 "ntrigger": grid.number_of_columns * grid.number_of_rows,
             }

--- a/mx3_beamline_library/schemas/detector.py
+++ b/mx3_beamline_library/schemas/detector.py
@@ -7,21 +7,15 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class UserData(BaseModel):
     """Data passed to the detector ZMQ-stream"""
 
-    sample_id: int = Field(description="Database ID of the sample")
     acquisition_uuid: UUID = Field(description="UUID of the acquisition")
+    collection_type: Literal["screening", "dataset", "one_shot", "grid_scan"]
     number_of_columns: int | None = Field(
         None, description="number of columns of the grid scan"
     )
     number_of_rows: int | None = Field(
         None, description="number of rows of the grid scan"
     )
-    crystal_id: int | None = None
-    data_collection_id: int
-    drop_location: str | None = Field(
-        None,
-        description="The location of the drop used to identify screening datasets",
-    )
-    collection_type: Literal["screening", "dataset", "one_shot", "grid_scan"]
+
     model_config = ConfigDict(extra="forbid")
 
 

--- a/mx3_beamline_library/schemas/detector.py
+++ b/mx3_beamline_library/schemas/detector.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -6,7 +7,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class UserData(BaseModel):
     """Data passed to the detector ZMQ-stream"""
 
-    sample_id: int = Field(description="ID of the sample")
+    sample_id: int = Field(description="Database ID of the sample")
+    acquisition_uuid: UUID = Field(description="UUID of the acquisition")
     number_of_columns: int | None = Field(
         None, description="number of columns of the grid scan"
     )
@@ -14,7 +16,7 @@ class UserData(BaseModel):
         None, description="number of rows of the grid scan"
     )
     crystal_id: int | None = None
-    data_collection_id: int = 0
+    data_collection_id: int
     drop_location: str | None = Field(
         None,
         description="The location of the drop used to identify screening datasets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mx3-beamline-library"
-version = "1.9.10"
+version = "2.0.0"
 description = "Ophyd devices and bluesky plans."
 authors = [
   { name = "Scientific Computing", email = "ScientificComputing@ansto.gov.au" },

--- a/tests/test_basic_scans.py
+++ b/tests/test_basic_scans.py
@@ -1,4 +1,5 @@
 import json
+from uuid import uuid4
 
 import httpx
 import numpy as np
@@ -35,16 +36,15 @@ def test_md3_scan(respx_mock, run_engine, sample_id, mocker: MockerFixture):
     )
 
     screening = md3_scan(
-        id=sample_id,
-        crystal_id=1,
+        acquisition_uuid=uuid4(),
         number_of_frames=1,
         scan_range=1,
         exposure_time=2,
-        data_collection_id=0,
         photon_energy=13.0,
         detector_distance=0.4,
         transmission=0.1,
         tray_scan=False,
+        collection_type="screening",
     )
 
     # Exercise
@@ -70,12 +70,10 @@ def test_md3_tray_scan(respx_mock, run_engine, sample_id, mocker: MockerFixture)
     )
 
     screening = md3_scan(
-        id=sample_id,
-        crystal_id=1,
+        acquisition_uuid=uuid4(),
         number_of_frames=1,
         scan_range=1,
         exposure_time=2,
-        data_collection_id=0,
         photon_energy=13.0,
         transmission=0.1,
         detector_distance=0.4,
@@ -88,7 +86,6 @@ def test_md3_tray_scan(respx_mock, run_engine, sample_id, mocker: MockerFixture)
             alignment_z=0,
             omega=90,
         ),
-        drop_location="A1-1",
     )
 
     # Exercise
@@ -100,7 +97,7 @@ def test_md3_tray_scan(respx_mock, run_engine, sample_id, mocker: MockerFixture)
 
 
 @respx.mock(assert_all_mocked=False)
-def test_md3_grid_scan(respx_mock, sample_id, run_engine, mocker: MockerFixture):
+def test_md3_grid_scan(respx_mock, run_engine, mocker: MockerFixture):
     # Setup
     arm = respx_mock.put("http://0.0.0.0:8000/detector/api/1.8.0/command/arm").mock(
         return_value=httpx.Response(200, content=json.dumps({"sequence id": 1}))
@@ -122,9 +119,8 @@ def test_md3_grid_scan(respx_mock, sample_id, run_engine, mocker: MockerFixture)
     )
 
     user_data = UserData(
-        sample_id=sample_id,
+        acquisition_uuid=uuid4(),
         collection_type="grid_scan",
-        data_collection_id=0,
     )
 
     # Exercise
@@ -156,7 +152,7 @@ def test_md3_grid_scan(respx_mock, sample_id, run_engine, mocker: MockerFixture)
 
 
 @respx.mock(assert_all_mocked=False)
-def test_md3_4d_scan(respx_mock, sample_id, run_engine, mocker: MockerFixture):
+def test_md3_4d_scan(respx_mock, run_engine, mocker: MockerFixture):
     # Setup
     arm = respx_mock.put("http://0.0.0.0:8000/detector/api/1.8.0/command/arm").mock(
         return_value=httpx.Response(200, content=json.dumps({"sequence id": 1}))
@@ -180,9 +176,8 @@ def test_md3_4d_scan(respx_mock, sample_id, run_engine, mocker: MockerFixture):
         ],
     )
     user_data = UserData(
-        sample_id=sample_id,
+        acquisition_uuid=uuid4(),
         collection_type="grid_scan",
-        data_collection_id=0,
     )
 
     # Exercise

--- a/tests/test_crystal_pics.py
+++ b/tests/test_crystal_pics.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import numpy as np
 import pytest
 from pytest_mock import MockerFixture
@@ -14,23 +16,14 @@ from mx3_beamline_library.plans.optical_centering import OpticalCentering
 def test_save_screen_crystal_pic_to_redis(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    crystal_counter = 1
-    data_collection_counter = 1
-    type = "screening"
     collection_stage = "start"
 
     # Execute
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    acquisition_uuid = uuid4()
+    save_screen_or_dataset_crystal_pic_to_redis(acquisition_uuid, collection_stage)
 
     # Verify
-    key = f"screening_pic:{collection_stage}:sample_{sample_id}:crystal_{crystal_counter}:data_collection_{data_collection_counter}"  # noqa
+    key = f"crystal_pic_{collection_stage}:{acquisition_uuid}"  # noqa
     result = fake_redis.get(key)
     assert result is not None
     assert isinstance(result, bytes)
@@ -39,23 +32,14 @@ def test_save_screen_crystal_pic_to_redis(fake_redis, mocker: MockerFixture):
 def test_save_dataset_crystal_pic_to_redis(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    crystal_counter = 1
-    data_collection_counter = 1
-    type = "dataset"
-    collection_stage = "start"
+    collection_stage = "end"
 
     # Execute
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    acquisition_uuid = uuid4()
+    save_screen_or_dataset_crystal_pic_to_redis(acquisition_uuid, collection_stage)
 
     # Verify
-    key = f"dataset_pic:{collection_stage}:sample_{sample_id}:crystal_{crystal_counter}:data_collection_{data_collection_counter}"  # noqa
+    key = f"crystal_pic_{collection_stage}:{acquisition_uuid}"  # noqa
     result = fake_redis.get(key)
     assert result is not None
     assert isinstance(result, bytes)
@@ -64,28 +48,13 @@ def test_save_dataset_crystal_pic_to_redis(fake_redis, mocker: MockerFixture):
 def test_get_screen_crystal_pic(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    crystal_counter = 1
-    data_collection_counter = 1
-    type = "screening"
     collection_stage = "start"
+    acquisition_uuid = uuid4()
 
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    save_screen_or_dataset_crystal_pic_to_redis(acquisition_uuid, collection_stage)
 
     # Execute
-    result = get_screen_or_dataset_crystal_pic(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    result = get_screen_or_dataset_crystal_pic(acquisition_uuid, collection_stage)
 
     # Verify
     assert result is not None
@@ -95,28 +64,13 @@ def test_get_screen_crystal_pic(fake_redis, mocker: MockerFixture):
 def test_get_dataset_crystal_pic(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    crystal_counter = 1
-    data_collection_counter = 1
-    type = "dataset"
-    collection_stage = "start"
+    collection_stage = "end"
+    acquisition_uuid = uuid4()
 
-    save_screen_or_dataset_crystal_pic_to_redis(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    save_screen_or_dataset_crystal_pic_to_redis(acquisition_uuid, collection_stage)
 
     # Execute
-    result = get_screen_or_dataset_crystal_pic(
-        sample_id,
-        crystal_counter,
-        data_collection_counter,
-        type,
-        collection_stage,
-    )
+    result = get_screen_or_dataset_crystal_pic(acquisition_uuid, collection_stage)
 
     # Verify
     assert result is not None
@@ -126,17 +80,13 @@ def test_get_dataset_crystal_pic(fake_redis, mocker: MockerFixture):
 def test_save_mxcube_grid_scan_crystal_pic(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    grid_scan_id = "test_grid_scan"
+    acquisition_uuid = uuid4()
 
     # Execute
-    save_mxcube_grid_scan_crystal_pic(
-        sample_id,
-        grid_scan_id,
-    )
+    save_mxcube_grid_scan_crystal_pic(acquisition_uuid)
 
     # Verify
-    key = f"mxcube_grid_scan_snapshot_{grid_scan_id}:{sample_id}"  # noqa
+    key = f"mxcube:grid_scan_snapshot:{acquisition_uuid}"  # noqa
     result = fake_redis.get(key)
     assert result is not None
     assert isinstance(result, bytes)
@@ -145,19 +95,12 @@ def test_save_mxcube_grid_scan_crystal_pic(fake_redis, mocker: MockerFixture):
 def test_get_grid_scan_mxcube_crystal_pic(fake_redis, mocker: MockerFixture):
     # Setup
     mocker.patch("mx3_beamline_library.plans.crystal_pics.redis_connection", fake_redis)
-    sample_id = "test_sample"
-    grid_scan_id = "1"
+    acquisition_uuid = uuid4()
 
-    save_mxcube_grid_scan_crystal_pic(
-        sample_id,
-        grid_scan_id,
-    )
+    save_mxcube_grid_scan_crystal_pic(acquisition_uuid)
 
     # Execute
-    result = get_grid_scan_crystal_pic(
-        sample_id,
-        grid_scan_id,
-    )
+    result = get_grid_scan_crystal_pic(acquisition_uuid=acquisition_uuid)
 
     # Verify
     assert result is not None
@@ -200,10 +143,7 @@ def test_get_grid_scan_udc_crystal_pic(
     run_engine(optical_centering.center_loop())
 
     # Execute
-    result = get_grid_scan_crystal_pic(
-        sample_id,
-        grid_scan_id,
-    )
+    result = get_grid_scan_crystal_pic(grid_scan_id=grid_scan_id, sample_id=sample_id)
 
     # Verify
     assert result is not None

--- a/tests/test_manual_xray_centering.py
+++ b/tests/test_manual_xray_centering.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 from pytest_mock.plugin import MockerFixture
 
@@ -8,8 +10,7 @@ from mx3_beamline_library.schemas.crystal_finder import MotorCoordinates
 @pytest.fixture()
 def xray_centering_instance(sample_id) -> ManualXRayCentering:
     return ManualXRayCentering(
-        sample_id=sample_id,
-        data_collection_id=0,
+        acquisition_uuid=uuid4(),
         grid_top_left_coordinate=(388, 502),
         grid_height=260,
         grid_width=364,

--- a/tests/test_xray_centering.py
+++ b/tests/test_xray_centering.py
@@ -1,4 +1,5 @@
 import pickle
+from uuid import uuid4
 
 import pytest
 from bluesky.plan_stubs import null
@@ -35,7 +36,7 @@ def x_ray_centering_instance(
 
     return XRayCentering(
         sample_id=sample_id,
-        data_collection_id=0,
+        acquisition_uuid=uuid4(),
         grid_scan_id="edge",
         detector_distance=0.496,  # m
         photon_energy=13,  # keV
@@ -63,13 +64,13 @@ def test_get_optical_centering_results_failure(mocker, sample_id, fake_redis):
     with pytest.raises(ValueError):
         result = XRayCentering(
             sample_id=sample_id,
-            data_collection_id=0,
+            acquisition_uuid=uuid4(),
             grid_scan_id="edge",
             detector_distance=0.496,  # m
             photon_energy=13,  # keV
+            transmission=0.1,
             omega_range=0,  # degrees
             md3_alignment_y_speed=10,  # mm/s
-            transmission=0.1,
             count_time=None,
             hardware_trigger=True,
         )
@@ -110,7 +111,7 @@ def test_calculate_md3_exposure_time_failure(
     with pytest.raises(ValueError):
         result = XRayCentering(
             sample_id=sample_id,
-            data_collection_id=0,
+            acquisition_uuid=uuid4(),
             grid_scan_id="edge",
             detector_distance=0.496,  # m
             photon_energy=13,  # keV

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "mx3-beamline-library"
-version = "1.9.10"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bitshuffle" },


### PR DESCRIPTION
* The `UserData` pydantic model now only requires `acquisition_uuid`, `collection_type` (and `number_of_columns`, and `number_of_rows` for grid scans).

* All changes in this PR are made to support this structure.